### PR TITLE
feat: move category name to the category itself

### DIFF
--- a/apps/docs/docs/examples/bank-account.md
+++ b/apps/docs/docs/examples/bank-account.md
@@ -52,14 +52,14 @@ export class Service {
   }
 
   static createMessageDb(context: Mdb.MessageDbContext, caching: Mdb.CachingStrategy) {
-    const category = Mdb.MessageDbCategory.create(context, codec, fold, initial, caching)
-    const resolve = (stayId: GuestStayId) => Decider.resolve(category, Category, streamId(stayId), null)
+    const category = Mdb.MessageDbCategory.create(context, Category, codec, fold, initial, caching)
+    const resolve = (stayId: GuestStayId) => Decider.resolve(category, streamId(stayId), null)
     return new Service(resolve)
   }
 
   static createMem(store: Mem.VolatileStore<Record<string, any>>) {
-    const category = Mem.MemoryStoreCategory.create(store, codec, fold, initial)
-    const resolve = (stayId: GuestStayId) => Decider.resolve(category, Category, streamId(stayId), null)
+    const category = Mem.MemoryStoreCategory.create(store, Category, codec, fold, initial)
+    const resolve = (stayId: GuestStayId) => Decider.resolve(category, streamId(stayId), null)
     return new Service(resolve)
   }
 }

--- a/apps/docs/docs/examples/invoice.md
+++ b/apps/docs/docs/examples/invoice.md
@@ -173,16 +173,16 @@ export class Service {
   }
 
   static createMessageDb(context: Mdb.MessageDbContext, caching: ICachingStrategy) {
-    const category = Mdb.MessageDbCategory.create(context, codec, fold, initial, caching)
+    const category = Mdb.MessageDbCategory.create(context, Category, codec, fold, initial, caching)
     const resolve = (invoiceId: InvoiceId) =>
-      Decider.resolve(category, Category, streamId(invoiceId), null)
+      Decider.resolve(category, streamId(invoiceId), null)
     return new Service(resolve)
   }
 
   static createMem(store: Mem.VolatileStore<string>) {
-    const category = Mem.MemoryStoreCategory.create(store, codec, fold, initial)
+    const category = Mem.MemoryStoreCategory.create(store, Category, codec, fold, initial)
     const resolve = (invoiceId: InvoiceId) =>
-      Decider.resolve(category, Category, streamId(invoiceId), null)
+      Decider.resolve(category, streamId(invoiceId), null)
     return new Service(resolve)
   }
 }

--- a/apps/docs/docs/intro.md
+++ b/apps/docs/docs/intro.md
@@ -63,14 +63,14 @@ export class Service {
   }
 
   static createMessageDb(context: Mdb.MessageDbContext, caching: Mdb.CachingStrategy) {
-    const category = Mdb.MessageDbCategory.create(context, codec, fold, initial, caching)
-    const resolve = (stayId: GuestStayId) => Decider.resolve(category, Category, streamId(stayId), null)
+    const category = Mdb.MessageDbCategory.create(context, Category, codec, fold, initial, caching)
+    const resolve = (stayId: GuestStayId) => Decider.resolve(category, streamId(stayId), null)
     return new Service(resolve)
   }
 
-  static createMem(store: Mem.VolatileStore<Record<string, any>>) {
-    const category = Mem.MemoryStoreCategory.create(store, codec, fold, initial)
-    const resolve = (stayId: GuestStayId) => Decider.resolve(category, Category, streamId(stayId), null)
+  static createMem(store: Mem.VolatileStore<string>) {
+    const category = Mem.MemoryStoreCategory.create(store, Category, codec, fold, initial)
+    const resolve = (stayId: GuestStayId) => Decider.resolve(category, streamId(stayId), null)
     return new Service(resolve)
   }
 }

--- a/apps/docs/src/examples/guest-stay.ts
+++ b/apps/docs/src/examples/guest-stay.ts
@@ -150,16 +150,16 @@ export class Service {
   }
 
   static createMessageDb(context: Mdb.MessageDbContext, caching: ICachingStrategy) {
-    const category = Mdb.MessageDbCategory.create(context, codec, fold, initial, caching)
+    const category = Mdb.MessageDbCategory.create(context, Category, codec, fold, initial, caching)
     const resolve = (stayId: GuestStayId) =>
-      Decider.resolve(category, Category, streamId(stayId), null)
+      Decider.resolve(category, streamId(stayId), null)
     return new Service(resolve)
   }
 
   static createMem(store: Mem.VolatileStore<string>) {
-    const category = Mem.MemoryStoreCategory.create(store, codec, fold, initial)
+    const category = Mem.MemoryStoreCategory.create(store, Category, codec, fold, initial)
     const resolve = (stayId: GuestStayId) =>
-      Decider.resolve(category, Category, streamId(stayId), null)
+      Decider.resolve(category, streamId(stayId), null)
     return new Service(resolve)
   }
 }

--- a/apps/docs/src/examples/invoice.ts
+++ b/apps/docs/src/examples/invoice.ts
@@ -170,16 +170,16 @@ export class Service {
   }
 
   static createMessageDb(context: Mdb.MessageDbContext, caching: ICachingStrategy) {
-    const category = Mdb.MessageDbCategory.create(context, codec, fold, initial, caching)
+    const category = Mdb.MessageDbCategory.create(context, Category, codec, fold, initial, caching)
     const resolve = (invoiceId: InvoiceId) =>
-      Decider.resolve(category, Category, streamId(invoiceId), null)
+      Decider.resolve(category, streamId(invoiceId), null)
     return new Service(resolve)
   }
 
   static createMem(store: Mem.VolatileStore<string>) {
-    const category = Mem.MemoryStoreCategory.create(store, codec, fold, initial)
+    const category = Mem.MemoryStoreCategory.create(store, Category, codec, fold, initial)
     const resolve = (invoiceId: InvoiceId) =>
-      Decider.resolve(category, Category, streamId(invoiceId), null)
+      Decider.resolve(category, streamId(invoiceId), null)
     return new Service(resolve)
   }
 }

--- a/apps/docs/src/examples/types.ts
+++ b/apps/docs/src/examples/types.ts
@@ -2,10 +2,11 @@ import { Uuid } from "@equinox-js/core"
 
 export type GuestStayId = Uuid.Uuid<"GuestStayId">
 export const GuestStayId = Uuid.create<"GuestStayId">
-export const ChargeId = Uuid.create<"ChargeId">()
 export type PaymentId = Uuid.Uuid<"PaymentId">
 export const PaymentId = Uuid.create<"PaymentId">()
 export type PayerId = Uuid.Uuid<"PayerId">
 export const PayerId = Uuid.create<"PayerId">()
 export type InvoiceId = Uuid.Uuid<"InvoiceId">
 export const InvoiceId = Uuid.create<"InvoiceId">()
+export type ChargeId = Uuid.Uuid<"ChargeId">
+export const ChargeId = Uuid.create<"ChargeId">()

--- a/apps/example/package.json
+++ b/apps/example/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "build": "tsc -p . --noEmit && tsup src/entrypoints/http.ts src/entrypoints/reactions.ts --format cjs",
     "start:http": "tsup src/entrypoints/http.ts --format cjs --onSuccess 'node dist/http.cjs'",
     "start:reactions": "tsup src/entrypoints/reactions.ts --format cjs --onSuccess 'node dist/reactions.cjs'",
     "test": "vitest run"

--- a/apps/example/src/config/equinox.ts
+++ b/apps/example/src/config/equinox.ts
@@ -12,6 +12,7 @@ export type Config =
 
 export const MessageDb = {
   createCached<E, S, C>(
+    name: string,
     codec: ICodec<E, string, C>,
     fold: (s: S, e: E[]) => S,
     initial: S,
@@ -20,20 +21,23 @@ export const MessageDb = {
   ) {
     const caching = CachingStrategy.slidingWindow(cache, 12e5)
     // prettier-ignore
-    return MessageDbCategory.create(context, codec, fold, initial, caching, access);
+    return MessageDbCategory.create(context, name, codec, fold, initial, caching, access);
   },
 
   createUnoptimized<E, S, C>(
+    name: string,
     codec: ICodec<E, string, C>,
     fold: (s: S, e: E[]) => S,
     initial: S,
     config: { context: MessageDbContext; cache: ICache },
   ) {
     const access = AccessStrategy.Unoptimized<E, S>()
-    return MessageDb.createCached(codec, fold, initial, access, config)
+    // prettier-ignore
+    return MessageDb.createCached(name, codec, fold, initial, access, config)
   },
 
   createSnapshotted<E, S, C>(
+    name: string,
     codec: ICodec<E, string, C>,
     fold: (s: S, e: E[]) => S,
     initial: S,
@@ -42,27 +46,32 @@ export const MessageDb = {
     config: { context: MessageDbContext; cache: ICache },
   ) {
     const access = AccessStrategy.AdjacentSnapshots(eventName, toSnapshot)
-    return MessageDb.createCached(codec, fold, initial, access, config)
+    // prettier-ignore
+    return MessageDb.createCached(name, codec, fold, initial, access, config)
   },
 
   createLatestKnown<E, S, C>(
+    name: string,
     codec: ICodec<E, string, C>,
     fold: (s: S, e: E[]) => S,
     initial: S,
     config: { context: MessageDbContext; cache: ICache },
   ) {
     const access = AccessStrategy.LatestKnownEvent<E, S>()
-    return MessageDb.createCached(codec, fold, initial, access, config)
+    // prettier-ignore
+    return MessageDb.createCached(name, codec, fold, initial, access, config)
   },
 }
 
 export const MemoryStore = {
   create<E, S, C>(
+    name: string,
     codec: ICodec<E, string, C>,
     fold: (s: S, e: E[]) => S,
     initial: S,
     { context: store }: { context: VolatileStore<string> },
   ) {
-    return MemoryStoreCategory.create(store, codec, fold, initial)
+    // prettier-ignore
+    return MemoryStoreCategory.create(store, name, codec, fold, initial)
   },
 }

--- a/apps/example/src/domain/invoice-auto-emailer.ts
+++ b/apps/example/src/domain/invoice-auto-emailer.ts
@@ -70,9 +70,9 @@ export class Service {
   static resolveCategory(config: Config.Config) {
     switch (config.store) {
       case Config.Store.Memory:
-        return Config.MemoryStore.create(codec, fold, initial, config)
+        return Config.MemoryStore.create(CATEGORY, codec, fold, initial, config)
       case Config.Store.MessageDb:
-        return Config.MessageDb.createLatestKnown(codec, fold, initial, config)
+        return Config.MessageDb.createLatestKnown(CATEGORY, codec, fold, initial, config)
     }
   }
 
@@ -81,7 +81,7 @@ export class Service {
     // could inject this via an argument too
     const emailer = new EmailSender()
     const category = Service.resolveCategory(config)
-    const resolve = (id: InvoiceId) => Decider.resolve(category, CATEGORY, streamId(id), null)
+    const resolve = (id: InvoiceId) => Decider.resolve(category, streamId(id), null)
     return new Service(payerService, emailer, resolve)
   }
 }

--- a/apps/example/src/domain/invoice.ts
+++ b/apps/example/src/domain/invoice.ts
@@ -176,15 +176,15 @@ export class Service {
   static resolveCategory(config: Config.Config) {
     switch (config.store) {
       case Config.Store.Memory:
-        return Config.MemoryStore.create(codec, fold, initial, config)
+        return Config.MemoryStore.create(CATEGORY, codec, fold, initial, config)
       case Config.Store.MessageDb:
-        return Config.MessageDb.createUnoptimized(codec, fold, initial, config)
+        return Config.MessageDb.createUnoptimized(CATEGORY, codec, fold, initial, config)
     }
   }
 
   static create(config: Config.Config) {
     const category = Service.resolveCategory(config)
-    const resolve = (id: InvoiceId) => Decider.resolve(category, CATEGORY, streamId(id), null)
+    const resolve = (id: InvoiceId) => Decider.resolve(category, streamId(id), null)
     return new Service(resolve)
   }
 }

--- a/apps/example/src/domain/payer.ts
+++ b/apps/example/src/domain/payer.ts
@@ -60,15 +60,15 @@ export class Service {
   static resolveCategory(config: Config.Config) {
     switch (config.store) {
       case Config.Store.Memory:
-        return Config.MemoryStore.create(codec, fold, initial, config)
+        return Config.MemoryStore.create(CATEGORY, codec, fold, initial, config)
       case Config.Store.MessageDb:
-        return Config.MessageDb.createLatestKnown(codec, fold, initial, config)
+        return Config.MessageDb.createLatestKnown(CATEGORY, codec, fold, initial, config)
     }
   }
 
   static create(config: Config.Config) {
     const category = Service.resolveCategory(config)
-    const resolve = (id: PayerId) => Decider.resolve(category, CATEGORY, streamId(id), null)
+    const resolve = (id: PayerId) => Decider.resolve(category, streamId(id), null)
     return new Service(resolve)
   }
 }

--- a/apps/store-integration/src/domain/Cart.ts
+++ b/apps/store-integration/src/domain/Cart.ts
@@ -175,6 +175,6 @@ export class Service {
   }
 
   static create(category: Equinox.Category<Events.Event, Fold.State>) {
-    return new Service((id) => Decider.resolve(category, Category, streamId(id), null))
+    return new Service((id) => Decider.resolve(category, streamId(id), null))
   }
 }

--- a/apps/store-integration/src/message-db.test.ts
+++ b/apps/store-integration/src/message-db.test.ts
@@ -6,7 +6,7 @@ import {
   MemoryCache,
   Codec,
   CachingStrategy,
-  ICachingStrategy
+  ICachingStrategy,
 } from "@equinox-js/core"
 import { describe, test, expect, afterEach, afterAll } from "vitest"
 import { Pool } from "pg"
@@ -17,7 +17,7 @@ import {
   AccessStrategy,
   MessageDbCategory,
   MessageDbConnection,
-  MessageDbContext
+  MessageDbContext,
 } from "@equinox-js/message-db"
 
 const Category = MessageDbCategory
@@ -41,7 +41,7 @@ namespace CartService {
       fold,
       initial,
       noCache,
-      AccessStrategy.Unoptimized()
+      AccessStrategy.Unoptimized(),
     )
     return Cart.Service.create(category)
   }
@@ -49,7 +49,7 @@ namespace CartService {
   export function createWithSnapshotStrategy(context: MessageDbContext) {
     const access = AccessStrategy.AdjacentSnapshots<E, S>(
       Cart.Fold.snapshotEventType,
-      Cart.Fold.snapshot
+      Cart.Fold.snapshot,
     )
     const category = Category.create(context, Cart.Category, codec, fold, initial, noCache, access)
     return Cart.Service.create(category)
@@ -65,9 +65,17 @@ namespace CartService {
   export function createWithSnapshotStrategyAndCaching(context: MessageDbContext) {
     const access = AccessStrategy.AdjacentSnapshots<E, S>(
       Cart.Fold.snapshotEventType,
-      Cart.Fold.snapshot
+      Cart.Fold.snapshot,
     )
-    const category = Category.create(context, Cart.Category, codec, fold, initial, sliding20m, access)
+    const category = Category.create(
+      context,
+      Cart.Category,
+      codec,
+      fold,
+      initial,
+      sliding20m,
+      access,
+    )
     return Cart.Service.create(category)
   }
 }
@@ -79,7 +87,7 @@ namespace ContactPreferencesService {
 
   const createWithLatestKnownEvent = (
     context: MessageDbContext,
-    cachingStrategy: ICachingStrategy
+    cachingStrategy: ICachingStrategy,
   ) => {
     const category = Category.create(
       context,
@@ -88,7 +96,7 @@ namespace ContactPreferencesService {
       fold,
       initial,
       cachingStrategy,
-      AccessStrategy.LatestKnownEvent()
+      AccessStrategy.LatestKnownEvent(),
     )
     return ContactPreferences.Service.create(category)
   }
@@ -102,7 +110,7 @@ namespace ContactPreferencesService {
 }
 
 const client = MessageDbConnection.create(
-  new Pool({ connectionString: "postgres://message_store:@127.0.0.1:5432/message_store" })
+  new Pool({ connectionString: "postgres://message_store:@127.0.0.1:5432/message_store" }),
 )
 
 const createContext = (connection: MessageDbConnection, batchSize: number) =>
@@ -139,7 +147,7 @@ namespace ContactPreferencesService {
       fold,
       initial,
       undefined,
-      AccessStrategy.LatestKnownEvent()
+      AccessStrategy.LatestKnownEvent(),
     )
     return ContactPreferences.Service.create(category)
   }
@@ -158,7 +166,7 @@ const assertSpans = (...expected: Record<string, any>[]) => {
   const attributes = getStoreSpans().map((x) => ({
     name: x.name,
     ...x.attributes,
-    status_message: x.status.message
+    status_message: x.status.message,
   }))
   expect(attributes).toEqual(expected.map(expect.objectContaining))
 }
@@ -178,7 +186,7 @@ namespace CartHelpers {
     cartId: Cart.CartId,
     skuId: Cart.SkuId,
     service: Cart.Service,
-    count: number
+    count: number,
   ) =>
     service.executeManyAsync(
       cartId,
@@ -191,15 +199,15 @@ namespace CartHelpers {
               yield { type: "SyncItem", context, skuId, quantity: 0 }
             }
           }
-        })()
-      )
+        })(),
+      ),
     )
   export const addAndThenRemoveItemsManyTimes = (
     context: Cart.Context,
     cartId: Cart.CartId,
     skuId: Cart.SkuId,
     service: Cart.Service,
-    count: number
+    count: number,
   ) => addAndThenRemoveItems(false, false, context, cartId, skuId, service, count)
 
   export const addAndThenRemoveItemsManyTimesExceptTheLastOne = (
@@ -207,7 +215,7 @@ namespace CartHelpers {
     cartId: Cart.CartId,
     skuId: Cart.SkuId,
     service: Cart.Service,
-    count: number
+    count: number,
   ) => addAndThenRemoveItems(false, true, context, cartId, skuId, service, count)
 
   export const addAndThenRemoveItemsOptimisticManyTimesExceptTheLastOne = (
@@ -215,7 +223,7 @@ namespace CartHelpers {
     cartId: Cart.CartId,
     skuId: Cart.SkuId,
     service: Cart.Service,
-    count: number
+    count: number,
   ) => addAndThenRemoveItems(true, true, context, cartId, skuId, service, count)
 }
 
@@ -237,15 +245,15 @@ describe("Roundtrips against the store", () => {
       cartId,
       skuId,
       service,
-      addRemoveCount
+      addRemoveCount,
     )
 
-    assertSpans(
-      {
-        name: "Transact", "eqx.batches": 1, "eqx.count": 0,
-        "eqx.append_count": 11
-      }
-    )
+    assertSpans({
+      name: "Transact",
+      "eqx.batches": 1,
+      "eqx.count": 0,
+      "eqx.append_count": 11,
+    })
     memoryExporter.reset()
 
     const state = await service.read(cartId)
@@ -268,20 +276,13 @@ describe("Roundtrips against the store", () => {
       prepare: () => Promise<void>,
       service: Cart.Service,
       skuId: string,
-      count: number
+      count: number,
     ) =>
       service.executeManyAsync(
         cartId,
         false,
-        [
-          {
-            type: "SyncItem",
-            skuId,
-            quantity: count,
-            context: cartContext
-          }
-        ],
-        prepare
+        [{ type: "SyncItem", skuId, quantity: count, context: cartContext }],
+        prepare,
       )
 
     const waiter = () => {
@@ -290,7 +291,7 @@ describe("Roundtrips against the store", () => {
         new Promise((res) => {
           resolve = res
         }),
-        () => resolve(undefined)
+        () => resolve(undefined),
       ] as const
     }
 
@@ -340,12 +341,10 @@ describe("Roundtrips against the store", () => {
       [sku11]: 11,
       [sku12]: 12,
       [sku21]: 21,
-      [sku22]: 22
+      [sku22]: 22,
     })
     const syncs = memoryExporter.getFinishedSpans().filter((x) => x.name === "Transact")
-    const conflicts = syncs.filter(
-      (x) => x.events.find(x => x.name == "Conflict")
-    )
+    const conflicts = syncs.filter((x) => x.events.find((x) => x.name == "Conflict"))
     expect(syncs).toHaveLength(4)
     expect(conflicts).toHaveLength(2)
   })
@@ -371,11 +370,14 @@ describe("Caching", () => {
       cartId,
       skuId,
       service1,
-      5
+      5,
     )
-    assertSpans(
-      { name: "Transact", "eqx.load_method": "BatchForward", "eqx.count": 0, "eqx.append_count": 9 }
-    )
+    assertSpans({
+      name: "Transact",
+      "eqx.load_method": "BatchForward",
+      "eqx.count": 0,
+      "eqx.append_count": 9,
+    })
     const staleRes = await service2.readStale(cartId)
     memoryExporter.reset()
     const freshRes = await service2.read(cartId)
@@ -386,7 +388,7 @@ describe("Caching", () => {
       "eqx.batches": 1,
       "eqx.count": 0,
       "eqx.start_position": 9,
-      "eqx.cache_hit": true
+      "eqx.cache_hit": true,
     })
     memoryExporter.reset()
 
@@ -398,11 +400,15 @@ describe("Caching", () => {
       cartId,
       skuId2,
       service1,
-      1
+      1,
     )
-    assertSpans(
-      { name: "Transact", "eqx.batches": 1, "eqx.count": 0, "eqx.cache_hit": true, "eqx.append_count": 1 }
-    )
+    assertSpans({
+      name: "Transact",
+      "eqx.batches": 1,
+      "eqx.count": 0,
+      "eqx.cache_hit": true,
+      "eqx.append_count": 1,
+    })
     memoryExporter.reset()
 
     const res = await service2.readStale(cartId)
@@ -421,7 +427,7 @@ describe("Caching", () => {
       cartId,
       skuId2,
       service1,
-      1
+      1,
     )
     assertSpans({ name: "Transact", "eqx.cache_hit": true, "eqx.allow_stale": true })
     expect(getStoreSpans()[0].attributes).not.to.have.property("eqx.batches")
@@ -433,7 +439,7 @@ describe("Caching", () => {
       cartId,
       skuId3,
       service1,
-      1
+      1,
     )
 
     // this time, we did something, so we see the append call
@@ -448,12 +454,15 @@ describe("Caching", () => {
       cartId,
       skuId4,
       service3,
-      1
+      1,
     )
     // Need 2 batches to do the reading
-    assertSpans(
-      { name: "Transact", "eqx.batches": 2, "eqx.cache_hit": false, "eqx.append_count": 1 }
-    )
+    assertSpans({
+      name: "Transact",
+      "eqx.batches": 2,
+      "eqx.cache_hit": false,
+      "eqx.append_count": 1,
+    })
     // we've engineered a clash with the cache state (service3 doest participate in caching)
     // Conflict with cached state leads to a read forward to resync; Then we'll idempotently decide not to do any append
     memoryExporter.reset()
@@ -462,13 +471,13 @@ describe("Caching", () => {
       cartId,
       skuId4,
       service2,
-      1
+      1,
     )
 
-    assertSpans(
-      { name: "Transact", "eqx.cache_hit": true, "eqx.allow_stale": true }
-    )
-    expect(memoryExporter.getFinishedSpans()[0].events).toEqual([expect.objectContaining({ name: "Conflict" })])
+    assertSpans({ name: "Transact", "eqx.cache_hit": true, "eqx.allow_stale": true })
+    expect(memoryExporter.getFinishedSpans()[0].events).toEqual([
+      expect.objectContaining({ name: "Conflict" }),
+    ])
   })
 })
 
@@ -480,7 +489,7 @@ describe("AccessStrategy.LatestKnownEvent", () => {
       littlePromotions: Math.random() > 0.5,
       manyPromotions: Math.random() > 0.5,
       productReview: Math.random() > 0.5,
-      quickSurveys: Math.random() > 0.5
+      quickSurveys: Math.random() > 0.5,
     }
 
     // Feed some junk into the stream
@@ -497,7 +506,7 @@ describe("AccessStrategy.LatestKnownEvent", () => {
     expect(result).toEqual(value)
     assertSpans(
       { name: "Transact", "eqx.load_method": "Last", "eqx.count": 1, "eqx.append_count": 1 },
-      { name: "Query", "eqx.load_method": "Last", "eqx.count": 1 }
+      { name: "Query", "eqx.load_method": "Last", "eqx.count": 1 },
     )
   })
 })
@@ -517,21 +526,25 @@ describe("AccessStrategy.AdjacentSnapshots", () => {
     await service.read(cartId)
     assertSpans(
       {
-        name: "Transact", "eqx.count": 0, "eqx.snapshot_version": -1,
-        "eqx.append_count": 8, "eqx.should_snapshot": false
+        name: "Transact",
+        "eqx.count": 0,
+        "eqx.snapshot_version": -1,
+        "eqx.append_count": 8,
+        "eqx.should_snapshot": false,
       },
-      { name: "Query", "eqx.count": 8, "eqx.snapshot_version": -1 }
+      { name: "Query", "eqx.count": 8, "eqx.snapshot_version": -1 },
     )
 
     // Add two more, which should push it over the threshold and hence trigger an append of a snapshot event
     memoryExporter.reset()
     await CartHelpers.addAndThenRemoveItemsManyTimes(cartContext, cartId, skuId, service, 1)
-    assertSpans(
-      {
-        name: "Transact", "eqx.count": 8, "eqx.snapshot_version": -1,
-        "eqx.append_count": 2, "eqx.should_snapshot": true
-      }
-    )
+    assertSpans({
+      name: "Transact",
+      "eqx.count": 8,
+      "eqx.snapshot_version": -1,
+      "eqx.append_count": 2,
+      "eqx.should_snapshot": true,
+    })
 
     // We now have 10 events and should be able to read them with a single call
     memoryExporter.reset()
@@ -541,12 +554,14 @@ describe("AccessStrategy.AdjacentSnapshots", () => {
     // Add 8 more; total of 18 should not trigger snapshotting as we snapshotted at Event Number 10
     memoryExporter.reset()
     await CartHelpers.addAndThenRemoveItemsManyTimes(cartContext, cartId, skuId, service, 4)
-    assertSpans(
-      {
-        name: "Transact", "eqx.count": 0, "eqx.snapshot_version": 10, "eqx.start_position": 10,
-        "eqx.append_count": 8, "eqx.should_snapshot": false
-      }
-    )
+    assertSpans({
+      name: "Transact",
+      "eqx.count": 0,
+      "eqx.snapshot_version": 10,
+      "eqx.start_position": 10,
+      "eqx.append_count": 8,
+      "eqx.should_snapshot": false,
+    })
 
     // While we now have 18 events, we should be able to read them with a single call
     memoryExporter.reset()
@@ -555,15 +570,20 @@ describe("AccessStrategy.AdjacentSnapshots", () => {
       name: "Query",
       "eqx.count": 8,
       "eqx.snapshot_version": 10,
-      "eqx.start_position": 10
+      "eqx.start_position": 10,
     })
 
     // add two more events, triggering a snapshot, then read it in a single snapshotted read
     memoryExporter.reset()
     await CartHelpers.addAndThenRemoveItemsManyTimes(cartContext, cartId, skuId, service, 1)
-    assertSpans(
-      { name: "Transact", "eqx.count": 8, "eqx.snapshot_version": 10, "eqx.start_position": 10, "eqx.append_count": 2, "eqx.should_snapshot": true }
-    )
+    assertSpans({
+      name: "Transact",
+      "eqx.count": 8,
+      "eqx.snapshot_version": 10,
+      "eqx.start_position": 10,
+      "eqx.append_count": 2,
+      "eqx.should_snapshot": true,
+    })
     // While we now have 18 events, we should be able to read them with a single call
     memoryExporter.reset()
     await service.read(cartId)
@@ -571,7 +591,7 @@ describe("AccessStrategy.AdjacentSnapshots", () => {
       name: "Query",
       "eqx.count": 0,
       "eqx.snapshot_version": 20,
-      "eqx.start_position": 20
+      "eqx.start_position": 20,
     })
   })
 
@@ -590,18 +610,24 @@ describe("AccessStrategy.AdjacentSnapshots", () => {
     await service2.read(cartId)
 
     assertSpans(
-      { name: "Transact", "eqx.count": 0, "eqx.snapshot_version": -1,
-      "eqx.should_snapshot": false},
-    { name: "Query", "eqx.count": 8, "eqx.snapshot_version": -1 }
+      {
+        name: "Transact",
+        "eqx.count": 0,
+        "eqx.snapshot_version": -1,
+        "eqx.should_snapshot": false,
+      },
+      { name: "Query", "eqx.count": 8, "eqx.snapshot_version": -1 },
     )
 
     // Add two more, which should push it over the threshold and hence trigger generation of a snapshot event
     memoryExporter.reset()
     await CartHelpers.addAndThenRemoveItemsManyTimes(cartContext, cartId, skuId, service1, 1)
-    assertSpans(
-      { name: "Transact", "eqx.count": 8, "eqx.snapshot_version": -1,
-      "eqx.should_snapshot": true }
-    )
+    assertSpans({
+      name: "Transact",
+      "eqx.count": 8,
+      "eqx.snapshot_version": -1,
+      "eqx.should_snapshot": true,
+    })
 
     // We now have 10 events, we should be able to read them with a single snapshotted read
     memoryExporter.reset()
@@ -611,10 +637,12 @@ describe("AccessStrategy.AdjacentSnapshots", () => {
     // Add 8 more; total of 18 should not trigger snapshotting as the snapshot is at version 10
     memoryExporter.reset()
     await CartHelpers.addAndThenRemoveItemsManyTimes(cartContext, cartId, skuId, service1, 4)
-    assertSpans(
-      { name: "Transact", "eqx.count": 0, "eqx.snapshot_version": 10,
-      "eqx.should_snapshot": false }
-    )
+    assertSpans({
+      name: "Transact",
+      "eqx.count": 0,
+      "eqx.snapshot_version": 10,
+      "eqx.should_snapshot": false,
+    })
 
     // While we now have 18 events, we should be able to read them with a single snapshotted read
     memoryExporter.reset()
@@ -624,9 +652,12 @@ describe("AccessStrategy.AdjacentSnapshots", () => {
     // ... trigger a second snapshotting
     memoryExporter.reset()
     await CartHelpers.addAndThenRemoveItemsManyTimes(cartContext, cartId, skuId, service1, 1)
-    assertSpans(
-      { name: "Transact", "eqx.count": 8, "eqx.snapshot_version": 10, "eqx.should_snapshot": true }
-    )
+    assertSpans({
+      name: "Transact",
+      "eqx.count": 8,
+      "eqx.snapshot_version": 10,
+      "eqx.should_snapshot": true,
+    })
 
     // and we _could_ reload the 20 events with a single slice read. However we are using the cache, which last saw it with 10 events, which necessitates two reads
     memoryExporter.reset()
@@ -642,7 +673,7 @@ test("Version is 0-based", async () => {
   const decider = SimplestThing.resolve(context, SimplestThing.categoryName, id)
   const [before, after] = await decider.transactExMapResult(
     (ctx) => [ctx.version, [{ type: "StuffHappened" }]],
-    (result, ctx) => [result, ctx.version]
+    (result, ctx) => [result, ctx.version],
   )
   expect([before, after]).toEqual([0n, 1n])
 })

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -14,7 +14,7 @@
     "build": "tsup src/index.ts --format esm,cjs --dts --clean",
     "test": "vitest run"
   },
-  "version": "1.0.0-alpha.8",
+  "version": "1.0.0-alpha.9",
   "files": [
     "./dist"
   ],

--- a/packages/core/src/lib/Decider.ts
+++ b/packages/core/src/lib/Decider.ts
@@ -347,10 +347,9 @@ export class Decider<Event, State> {
 
   static resolve<E, S, C>(
     category: Category<E, S, C>,
-    categoryName: string,
     streamId: string,
     context: C,
   ) {
-    return new Decider(category.stream(context, categoryName, streamId))
+    return new Decider(category.stream(context, streamId))
   }
 }

--- a/packages/memory-store/package.json
+++ b/packages/memory-store/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "build": "tsup src/index.ts --format esm,cjs --dts --clean"
   },
-  "version": "1.0.0-alpha.8",
+  "version": "1.0.0-alpha.9",
   "devDependencies": {
     "@types/node": "^18.11.18",
     "tsconfig": "workspace:*",

--- a/packages/message-db-consumer/package.json
+++ b/packages/message-db-consumer/package.json
@@ -15,7 +15,7 @@
     "build": "tsup src/index.ts --format esm,cjs --dts --clean",
     "test": "vitest run"
   },
-  "version": "1.0.0-alpha.8",
+  "version": "1.0.0-alpha.9",
   "files": [
     "./dist"
   ],

--- a/packages/message-db/package.json
+++ b/packages/message-db/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "build": "tsup src/index.ts --format esm,cjs --dts --clean"
   },
-  "version": "1.0.0-alpha.8",
+  "version": "1.0.0-alpha.9",
   "files": [
     "./dist"
   ],

--- a/packages/message-db/src/lib/Category.ts
+++ b/packages/message-db/src/lib/Category.ts
@@ -1,5 +1,4 @@
 import type {
-  ICategory,
   IEventData,
   StreamToken,
   SyncResult,

--- a/packages/message-db/src/lib/Category.ts
+++ b/packages/message-db/src/lib/Category.ts
@@ -165,8 +165,6 @@ export class MessageDbContext {
   }
 
   async trySync(
-    category: string,
-    streamId: string,
     streamName: string,
     token: StreamToken,
     encodedEvents: IEventData<Format>[],
@@ -232,6 +230,7 @@ class InternalCategory<Event, State, Context>
 {
   constructor(
     private readonly context: MessageDbContext,
+    private readonly categoryName: string,
     private readonly codec: ICodec<Event, Format, Context>,
     private readonly fold: (state: State, events: Event[]) => State,
     private readonly initial: State,
@@ -239,13 +238,16 @@ class InternalCategory<Event, State, Context>
   ) {}
 
   private async loadAlgorithm(
-    category: string,
     streamId: string,
-    streamName: string,
     requireLeader: boolean,
   ): Promise<[StreamToken, State]> {
+    const streamName = Equinox.StreamName.compose(this.categoryName, streamId)
     const span = trace.getActiveSpan()
-    span?.setAttribute("eqx.access_strategy", this.access.type)
+    span?.setAttributes({
+      "eqx.access_strategy": this.access.type,
+      "eqx.category": this.categoryName,
+      "eqx.stream_name": streamName,
+    })
     switch (this.access.type) {
       case "Unoptimized":
         return this.context.loadBatched(
@@ -265,7 +267,7 @@ class InternalCategory<Event, State, Context>
         )
       case "AdjacentSnapshots": {
         const result = await this.context.loadSnapshot(
-          category,
+          this.categoryName,
           streamId,
           requireLeader,
           this.codec.tryDecode,
@@ -296,12 +298,13 @@ class InternalCategory<Event, State, Context>
 
   supersedes = Token.supersedes
 
-  async load(category: string, streamId: string, streamName: string, requireLeader: boolean) {
-    const [token, state] = await this.loadAlgorithm(category, streamId, streamName, requireLeader)
+  async load(streamId: string, requireLeader: boolean) {
+    const [token, state] = await this.loadAlgorithm(streamId, requireLeader)
     return { token, state }
   }
 
-  async reload(streamName: string, requireLeader: boolean, t: TokenAndState<State>) {
+  async reload(streamId: string, requireLeader: boolean, t: TokenAndState<State>) {
+    const streamName = Equinox.StreamName.compose(this.categoryName, streamId)
     const [token, state] = await this.context.reload(
       streamName,
       requireLeader,
@@ -314,23 +317,26 @@ class InternalCategory<Event, State, Context>
   }
 
   async trySync(
-    category: string,
     streamId: string,
-    streamName: string,
     ctx: Context,
     token: StreamToken,
     state: State,
     events: Event[],
   ): Promise<SyncResult<State>> {
     const span = trace.getActiveSpan()
+    const streamName = Equinox.StreamName.compose(this.categoryName, streamId)
+    span?.setAttributes({
+      "eqx.category": this.categoryName,
+      "eqx.stream_name": streamName,
+    })
     const encode = (ev: Event) => this.codec.encode(ev, ctx)
     const encodedEvents = await Promise.all(events.map(encode))
-    const result = await this.context.trySync(category, streamId, streamName, token, encodedEvents)
+    const result = await this.context.trySync(streamName, token, encodedEvents)
     switch (result.type) {
       case "ConflictUnknown":
         return {
           type: "Conflict",
-          resync: () => this.reload(streamName, true, { token, state }),
+          resync: () => this.reload(streamId, true, { token, state }),
         }
       case "Written": {
         const newState = this.fold(state, events)
@@ -344,7 +350,7 @@ class InternalCategory<Event, State, Context>
             span?.setAttribute("eqx.should_snapshot", shouldSnapshot)
             if (shouldSnapshot) {
               await this.storeSnapshot(
-                category,
+                this.categoryName,
                 streamId,
                 ctx,
                 result.token,
@@ -371,34 +377,19 @@ class InternalCategory<Event, State, Context>
   }
 }
 
-export class MessageDbCategory<Event, State, Context = null> extends Equinox.Category<
-  Event,
-  State,
-  Context
-> {
-  constructor(
-    resolveInner: (
-      categoryName: string,
-      streamId: string,
-    ) => readonly [ICategory<Event, State, Context>, string],
-    empty: TokenAndState<State>,
-  ) {
-    super(resolveInner, empty)
-  }
-
+export class MessageDbCategory {
   static create<Event, State, Context = null>(
     context: MessageDbContext,
+    categoryName: string,
     codec: ICodec<Event, Format, Context>,
     fold: (state: State, events: Event[]) => State,
     initial: State,
     caching: ICachingStrategy = CachingStrategy.noCache(),
     access?: AccessStrategy<Event, State>,
   ) {
-    const inner = new InternalCategory(context, codec, fold, initial, access)
-    const category = CachingCategory.apply(inner, caching)
-    const resolveInner = (categoryName: string, streamId: string) =>
-      [category, `${categoryName}-${streamId}`] as const
+    const inner = new InternalCategory(context, categoryName, codec, fold, initial, access)
+    const category = CachingCategory.apply(categoryName, inner, caching)
     const empty: TokenAndState<State> = { token: context.tokenEmpty, state: initial }
-    return new MessageDbCategory(resolveInner, empty)
+    return new Equinox.Category(category, empty)
   }
 }


### PR DESCRIPTION
This line keeps tripping people up:
```ts
const decider = Decider.resolve(category, 'CategoryName', streamId, context)
```

in particular, category being passed separately from CategoryName. Having to include name when creating category makes more sense to people