### PR TITLE
fix build

### DIFF
--- a/packages/message-db-consumer/package.json
+++ b/packages/message-db-consumer/package.json
@@ -1,13 +1,12 @@
 {
   "name": "@equinox-js/message-db-consumer",
-  "main": "./dist/index.cjs",
-  "type": "module",
-  "module": "./dist/index.js",
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "require": "./dist/index.cjs",
-      "import": "./dist/index.js",
+      "require": "./dist/index.js",
+      "import": "./dist/index.mjs",
       "types": "./dist/index.d.ts"
     }
   },

--- a/packages/message-db-consumer/src/lib/MessageDbSource.ts
+++ b/packages/message-db-consumer/src/lib/MessageDbSource.ts
@@ -2,9 +2,9 @@ import { MessageDbCategoryReader } from "./MessageDbClient.js"
 import { ICheckpointer } from "./Checkpoints.js"
 import { ITimelineEvent } from "@equinox-js/core"
 import { Pool } from "pg"
-import pLimit from "p-limit"
 import { SpanKind, SpanStatusCode, trace } from "@opentelemetry/api"
 import { sleep } from "./Sleep.js"
+const pLimit = require("p-limit")
 
 type Options = {
   categories: string[]

--- a/packages/message-db-consumer/tsconfig.json
+++ b/packages/message-db-consumer/tsconfig.json
@@ -1,7 +1,4 @@
 {
   "extends": "tsconfig/base.json",
-  "compilerOptions": {
-    "declarationMap": true
-  },
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
Consolidate build.

Fix `TS1479: The current file is a CommonJS module whose imports will produce 'require' calls; however, the referenced file is an ECMAScript module and cannot be imported with 'require'. Consider writing a dynamic 'import("@equinox-js/message-db-consumer")' call instead.`