### PR TITLE
Optimised SQL read models

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,0 @@
-packages/projection-pg/src/collapse.ts

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+packages/projection-pg/src/collapse.ts

--- a/apps/example/package.json
+++ b/apps/example/package.json
@@ -13,6 +13,7 @@
     "@equinox-js/memory-store": "workspace:*",
     "@equinox-js/message-db": "workspace:*",
     "@equinox-js/message-db-consumer": "workspace:*",
+    "@equinox-js/projection-pg": "workspace:*",
     "@honeycombio/opentelemetry-node": "^0.5.0",
     "@opentelemetry/api": "^1.4.0",
     "@opentelemetry/instrumentation-express": "^0.33.0",

--- a/apps/example/src/domain/payer.ts
+++ b/apps/example/src/domain/payer.ts
@@ -4,7 +4,7 @@ import z from "zod"
 import { equals } from "ramda"
 import * as Config from "../config/equinox.js"
 
-const CATEGORY = "Payer"
+export const CATEGORY = "Payer"
 const streamId = StreamId.gen(PayerId.toString)
 
 export const PayerProfileSchema = z.object({

--- a/apps/example/src/entrypoints/payer-read-model.ts
+++ b/apps/example/src/entrypoints/payer-read-model.ts
@@ -1,0 +1,31 @@
+import "./tracing.js"
+import { MessageDbSource, PgCheckpoints } from "@equinox-js/message-db-consumer"
+import pg from "pg"
+import { Payer } from "../domain/index.js"
+import * as PayerReadModel from '../read-models/PayerReadModel.js'
+
+const createPool = (connectionString?: string) =>
+  connectionString ? new pg.Pool({ connectionString, max: 10 }) : undefined
+
+const messageDbPool = createPool(process.env.MDB_RO_CONN_STR || process.env.MDB_CONN_STR)!
+const pool = createPool(process.env.CP_CONN_STR)!
+const checkpointer = new PgCheckpoints(pool)
+checkpointer.ensureTable().then(() => console.log("table created"))
+
+const source = MessageDbSource.create({
+  pool: messageDbPool, 
+  batchSize: 500,
+  categories: [Payer.CATEGORY],
+  groupName: "PayerReadModel",
+  checkpointer,
+  handler: PayerReadModel.createHandler(pool),
+  tailSleepIntervalMs: 100,
+  maxConcurrentStreams: 10,
+})
+
+const ctrl = new AbortController()
+
+process.on("SIGINT", () => ctrl.abort())
+process.on("SIGTERM", () => ctrl.abort())
+
+source.start(ctrl.signal)

--- a/apps/example/src/read-models/PayerReadModel.ts
+++ b/apps/example/src/read-models/PayerReadModel.ts
@@ -1,0 +1,33 @@
+import { ITimelineEvent, StreamName } from "@equinox-js/core"
+import { Pool } from "pg"
+import { PayerId } from "../domain/identifiers.js"
+import { Payer } from "../domain//index.js"
+import { Upsert, Delete, Change, createProjection } from "@equinox-js/projection-pg"
+
+type Payer = { id: PayerId; name: string; email: string }
+
+export const projection = { table: "payer", id: ["id"] }
+
+function changes(stream: string, events: ITimelineEvent<string>[]): Change<Payer>[] {
+  const id = PayerId.parse(StreamName.parseId(stream))
+  const event = Payer.codec.tryDecode(events[events.length - 1])
+  if (!event) return []
+  switch (event.type) {
+    case "PayerProfileUpdated":
+      const data = event.data
+      return [Upsert({ id: id, name: data.name, email: data.email })]
+    case "PayerDeleted":
+      return [Delete<Payer>({ id: id })]
+  }
+}
+
+export const ensureTable = (pool: Pool) =>
+  pool.query(
+    `create table if not exists payer (
+      id uuid not null primary key,
+      name text not null,
+      email text not null
+    )`,
+  )
+
+export const createHandler = (pool: Pool) => createProjection(projection, pool, changes)

--- a/apps/example/test/read-models/PayerReadModel.test.ts
+++ b/apps/example/test/read-models/PayerReadModel.test.ts
@@ -1,0 +1,88 @@
+import { ITimelineEvent, StreamName } from "@equinox-js/core"
+import { Pool } from "pg"
+import { describe, test, expect } from "vitest"
+import { PayerId } from "../../src/domain/identifiers.js"
+import * as Payer from "../../src/domain/payer.js"
+import * as PayerReadModel from "../../src/read-models/PayerReadModel.js"
+
+const updated: Payer.Event = {
+  type: "PayerProfileUpdated",
+  data: {
+    name: "Test",
+    email: "test@example.com",
+  },
+}
+const updated2: Payer.Event = {
+  type: "PayerProfileUpdated",
+  data: {
+    name: "Test 2",
+    email: "test@example.com",
+  },
+}
+
+const deleted: Payer.Event = { type: "PayerDeleted" }
+
+describe("PayerReadModel", () => {
+  scenario("empty").then([])
+
+  scenario("a single payer profile updated")
+    .given([updated])
+    .then([{ name: "Test", email: "test@example.com" }])
+
+  scenario("a single payer profile updated and deleted").given([updated, deleted]).then([])
+
+  scenario("a single payer profile updated twice")
+    .given([updated, updated2])
+    .then([{ name: "Test 2", email: "test@example.com" }])
+
+  scenario("Different payers updated")
+    .given([updated])
+    .given([updated2])
+    .then([
+      { name: "Test", email: "test@example.com" },
+      { name: "Test 2", email: "test@example.com" },
+    ])
+
+  const payerId = PayerId.create()
+  scenario("deleted in a different batch").given([updated], payerId).given([deleted], payerId)
+})
+
+function scenario(name: string, batches: [string, ITimelineEvent<string>[]][] = []) {
+  return {
+    given: (events: Payer.Event[], payerId = PayerId.create()) => {
+      const streamName = StreamName.compose(Payer.CATEGORY, payerId)
+      return scenario(
+        name,
+        batches.concat([
+          [
+            streamName,
+            events.map((event) => Payer.codec.encode(event, null) as ITimelineEvent<string>),
+          ],
+        ]),
+      )
+    },
+    then(table: any[]) {
+      test(name, async () => {
+        const pool = new Pool({
+          connectionString: "postgres://postgres:postgres@localhost:5432/postgres",
+          // we start a transaction in the beforeAll hook and roll it back after each test
+          max: 1,
+        })
+        await PayerReadModel.ensureTable(pool)
+        await pool.query("begin")
+        try {
+          await pool.query("truncate table payer")
+          const handler = PayerReadModel.createHandler(pool)
+          for (const [stream, batch] of batches) {
+            await handler(stream, batch)
+          }
+          const result = await pool.query("select * from payer")
+          expect(result.rows).toEqual(table.map(expect.objectContaining))
+        } finally {
+          await pool.query("rollback")
+          await pool.end()
+        }
+      })
+    },
+  }
+}

--- a/apps/example/test/read-models/PayerReadModel.test.ts
+++ b/apps/example/test/read-models/PayerReadModel.test.ts
@@ -47,7 +47,7 @@ describe("PayerReadModel", () => {
   scenario("deleted in a different batch").given([updated], payerId).given([deleted], payerId)
 })
 
-function scenario(name: string, batches: [string, ITimelineEvent<string>[]][] = []) {
+function scenario(name: string, batches: [string, ITimelineEvent<string>[]][] = [], version = 0) {
   return {
     given: (events: Payer.Event[], payerId = PayerId.create()) => {
       const streamName = StreamName.compose(Payer.CATEGORY, payerId)
@@ -56,9 +56,14 @@ function scenario(name: string, batches: [string, ITimelineEvent<string>[]][] = 
         batches.concat([
           [
             streamName,
-            events.map((event) => Payer.codec.encode(event, null) as ITimelineEvent<string>),
+            events.map((event) => {
+              const encoded = Payer.codec.encode(event, null) as ITimelineEvent<string>
+              encoded.index = BigInt(version++)
+              return encoded
+            }),
           ],
         ]),
+        version + events.length,
       )
     },
     then(table: any[]) {

--- a/docs/docs/reactions/considerations.md
+++ b/docs/docs/reactions/considerations.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 1
+---
 # Considerations
 
 In the previous section we learned about reactions but we omitted some important

--- a/docs/docs/reactions/pg-projections.md
+++ b/docs/docs/reactions/pg-projections.md
@@ -1,0 +1,120 @@
+---
+sidebar_position: 3
+---
+
+# PG Projections
+
+We provide `@equinox-js/projection-pg` as a simple way to create SQL
+read models. It allows you to define your `Changes` function without
+writing raw SQL. We could write the payer projection in the previous section as:
+
+```ts
+import { Change, Upsert, Delete, Projection } from "@equinox-js/projection-pg"
+import { Pool } from "pg"
+type Payer = { id: PayerId; name: string; email: string }
+type Id = "id"
+type PayerChange = Change<Payer, Id>
+
+function changes(streamName: string, events: ITimelineEvent<string>[]): Sql[] {
+  const payerId = PayerId.parse(StreamName.parseId(streamName))
+  // Payer is a LatestKnownEvent stream so we only need the last event
+  const event = Payer.codec.tryDecode(events[events.length - 1])
+  if (!event) return []
+  switch (event.type) {
+    case "PayerProfileUpdated":
+      return [Upsert({ id, name: event.data.name, email: event.data.email })]
+    case "PayerDeleted":
+      return [Delete({ id })]
+  }
+}
+
+export const createHandler = (pool: Pool) => {
+  const viewData = new ViewData<Payer, Id>("payer", ["id"])
+  return viewData.createHandler(pool, changes)
+}
+```
+
+To wire it up we would do
+
+```ts
+import { MessageDbSource, PgCheckpoints } from "@equinox-js/message-db-consumer"
+import { ViewData } from "@equinox-js/view-data-pg"
+import PayerViewModel from "./view-models/payer"
+import pg from "pg"
+
+const pool = new pg.Pool({ connectionString: "..." })
+const checkpointer = new PgCheckpoints(pool, "public")
+const messageDbPool = new pg.Pool({ connectionString: "..." })
+
+const source = MessageDbSource.create({
+  pool: messageDbPool,
+  batchSize: 500,
+  categories: [Payer.CATEGORY],
+  groupName: "PayerListModel",
+  checkpointer,
+  handler: PayerViewModel.createHandler(pool),
+  tailSleepIntervalMs: 5000,
+  maxConcurrentStreams: 10,
+})
+
+const ctrl = new AbortController()
+
+process.on("SIGINT", () => ctrl.abort())
+process.on("SIGTERM", () => ctrl.abort())
+
+await source.start(ctrl.signal)
+```
+
+## Extended example
+
+```ts
+import { Change, Insert, Upsert, Delete, Projection } from "@equinox-js/projection-pg"
+import { Pool } from "pg"
+type Appointment = {
+  id: AppointmentId
+  title: string
+  start: Date
+  duration_ms: number
+  is_cancelled: boolean
+}
+type Id = "id"
+type AppointmentChange = Change<Appointment, Id>
+
+function changes(streamName: string, events: ITimelineEvent<string>[]): Sql[] {
+  const id = AppointmentId.parse(StreamName.parseId(streamName))
+  // Payer is a LatestKnownEvent stream so we only need the last event
+  const decodedEvents = keepMap(events, Appointment.codec.tryDecode)
+  const result: AppointmentChange[] = []
+  for (const event of decodedEvents) {
+    const data = event.data
+    switch (event.type) {
+      case "AppointmentScheduled":
+        result.push(
+          Insert({
+            id,
+            title: data.title,
+            start: data.start,
+            duration_ms: data.duration_ms,
+            is_cancelled: false,
+          }),
+        )
+      case "AppointmentRescheduled":
+        result.push(Update({ id, start: data.start }))
+      case "AppointmentCancelled":
+        result.push(Update({ id, is_cancelled: true }))
+    }
+  }
+  return result
+}
+
+export const createHandler = (pool: Pool) => {
+  const viewData = new ViewData<Appointment, Id>("appointment", ["id"])
+  return viewData.createHandler(pool, changes)
+}
+```
+
+The library will automatically fold the changes into the smallest changeset
+required. So if you have an `insert + update + update` it'll be a single
+`insert`. An `insert + update + delete` will be a no-op
+
+

--- a/docs/docs/reactions/projections.md
+++ b/docs/docs/reactions/projections.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 2
+---
 # Projections
 
 As discussed, Projections are a form of reaction, and a fairly generalisable one

--- a/packages/projection-pg/.prettierignore
+++ b/packages/projection-pg/.prettierignore
@@ -1,0 +1,1 @@
+src/collapse.ts

--- a/packages/projection-pg/README.md
+++ b/packages/projection-pg/README.md
@@ -1,3 +1,3 @@
-# view-data-pg
+# projection-pg
 
 A utility library for creating SQL view models

--- a/packages/projection-pg/README.md
+++ b/packages/projection-pg/README.md
@@ -1,0 +1,3 @@
+# view-data-pg
+
+A utility library for creating SQL view models

--- a/packages/projection-pg/package.json
+++ b/packages/projection-pg/package.json
@@ -29,7 +29,6 @@
   },
   "dependencies": {
     "@equinox-js/core": "workspace:*",
-    "@opentelemetry/api": "^1.4.0",
     "knex": "^2.5.1",
     "pg": "^8.8.0"
   }

--- a/packages/projection-pg/package.json
+++ b/packages/projection-pg/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@equinox-js/projection-pg",
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "require": "./dist/index.js",
+      "import": "./dist/index.mjs",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "scripts": {
+    "build": "tsup src/index.ts --format esm,cjs --dts --clean",
+    "test": "vitest run"
+  },
+  "version": "1.0.0-alpha.12",
+  "files": [
+    "./dist"
+  ],
+  "devDependencies": {
+    "@types/knex": "^0.16.1",
+    "@types/node": "^18.11.18",
+    "@types/pg": "^8.6.6",
+    "tsconfig": "workspace:*",
+    "tsup": "^6.5.0",
+    "typescript": "^4.7.4",
+    "vitest": "^0.25.3"
+  },
+  "dependencies": {
+    "@equinox-js/core": "workspace:*",
+    "@opentelemetry/api": "^1.4.0",
+    "knex": "^2.5.1",
+    "pg": "^8.8.0"
+  }
+}

--- a/packages/projection-pg/src/collapse.ts
+++ b/packages/projection-pg/src/collapse.ts
@@ -1,5 +1,7 @@
 import { Action, Change, Insert, Update, Upsert } from "./types"
 
+// Note: do not run prettier over this file, it does a bad job and makes it harder to read
+
 export function collapseChanges(changes: Change[]): Change | undefined {
   if (changes.length <= 1) return changes[0]
 
@@ -9,59 +11,31 @@ export function collapseChanges(changes: Change[]): Change | undefined {
   switch (first.type) {
     case Action.Insert:
       switch (second.type) {
-        case Action.Insert:
-          throw new Error("Cannot insert the same record twice, use Upsert")
-        case Action.Update:
-          return collapseChanges([
-            Insert({ ...first.data, ...second.data }),
-            ...changes.slice(2),
-          ])
-        case Action.Upsert:
-          return collapseChanges([Insert({ ...first.data, ...second.data }), ...changes.slice(2)])
-        case Action.Delete:
-          return collapseChanges(changes.slice(2))
+        case Action.Insert: throw new Error("Cannot insert the same record twice, use Upsert")
+        case Action.Update: return collapseChanges([Insert({ ...first.data, ...second.data }), ...changes.slice(2)])
+        case Action.Upsert: return collapseChanges([Insert({ ...first.data, ...second.data }), ...changes.slice(2)])
+        case Action.Delete: return collapseChanges(changes.slice(2))
       }
     case Action.Update:
       switch (second.type) {
-        case Action.Insert:
-          throw new Error("Cannot insert after updating the same record, use Upsert")
-        case Action.Update:
-          return collapseChanges([
-            Update({ ...first.data, ...second.data }),
-            ...changes.slice(2),
-          ])
-        case Action.Upsert:
-          return collapseChanges([second, ...changes.slice(2)])
-        case Action.Delete:
-          return collapseChanges(changes.slice(1))
+        case Action.Insert: throw new Error("Cannot insert after updating the same record, use Upsert")
+        case Action.Update: return collapseChanges([Update({ ...first.data, ...second.data }), ...changes.slice(2)])
+        case Action.Upsert: return collapseChanges([second, ...changes.slice(2)])
+        case Action.Delete: return collapseChanges(changes.slice(1))
       }
     case Action.Upsert:
       switch (second.type) {
-        case Action.Insert:
-          throw new Error("Cannot insert after upserting the same record, use Upsert")
-        case Action.Update:
-          return collapseChanges([
-            Upsert({ ...first.data, ...second.data }),
-            ...changes.slice(2),
-          ])
-        case Action.Upsert:
-          return collapseChanges([
-            Upsert({ ...first.data, ...second.data }),
-            ...changes.slice(2),
-          ])
-        case Action.Delete:
-          return collapseChanges(changes.slice(1))
+        case Action.Insert: throw new Error("Cannot insert after upserting the same record, use Upsert")
+        case Action.Update: return collapseChanges([Upsert({ ...first.data, ...second.data }), ...changes.slice(2)])
+        case Action.Upsert: return collapseChanges([Upsert({ ...first.data, ...second.data }), ...changes.slice(2)])
+        case Action.Delete: return collapseChanges(changes.slice(1))
       }
     case Action.Delete:
       switch (second.type) {
-        case Action.Insert:
-          return collapseChanges([Update(second.data), ...changes.slice(2)])
-        case Action.Update:
-          throw new Error("Cannot update after deleting the same record, use Upsert")
-        case Action.Upsert:
-          return collapseChanges(changes.slice(1))
-        case Action.Delete:
-          return collapseChanges(changes.slice(1))
+        case Action.Insert: return collapseChanges([Update(second.data), ...changes.slice(2)])
+        case Action.Update: throw new Error("Cannot update after deleting the same record, use Upsert")
+        case Action.Upsert: return collapseChanges(changes.slice(1))
+        case Action.Delete: return collapseChanges(changes.slice(1))
       }
   }
 }

--- a/packages/projection-pg/src/collapse.ts
+++ b/packages/projection-pg/src/collapse.ts
@@ -1,0 +1,77 @@
+import { Action, Change, Insert, Update, Upsert } from "./types"
+
+export function collapseChanges<T extends Record<string, any>, Ids extends keyof T>(
+  changes: Change<T, Ids>[],
+): Change<T, Ids>[] {
+  if (changes.length <= 1) return changes
+
+  const first = changes[0]
+  const second = changes[1]
+
+  // Insert, Insert
+  if (first.type === Action.Insert && second.type === Action.Insert) {
+    throw new Error('Cannot insert the same record twice, use Upsert')
+  }
+  // Insert, Update
+  if (first.type === Action.Insert && second.type === Action.Update) {
+    return collapseChanges([Insert<T>({ ...first.data, ...second.data }), ...changes.slice(2)])
+  }
+  // Insert, Upsert: Upsert is a full replace so we can just drop the insert
+  if (first.type === Action.Insert && second.type === Action.Upsert) {
+    return collapseChanges([second, ...changes.slice(2)])
+  }
+  // Insert, Delete
+  if (first.type === Action.Insert && second.type === Action.Delete) {
+    return collapseChanges(changes.slice(2))
+  }
+  // Update, Insert
+  if (first.type === Action.Update && second.type === Action.Insert) {
+    throw new Error('Cannot insert after updating the same record, use Upsert')
+  }
+  // Update, Update
+  if (first.type === Action.Update && second.type === Action.Update) {
+    return collapseChanges([Update<T, Ids>({ ...first.data, ...second.data }), ...changes.slice(2)])
+  }
+  // Update, Upsert: Upsert is a full replace so we can just drop the update
+  if (first.type === Action.Update && second.type === Action.Upsert) {
+    return collapseChanges([second, ...changes.slice(2)])
+  }
+  // Update, Delete: Update indicates the record exists, so we can drop the update and keep the delete 
+  if (first.type === Action.Update && second.type === Action.Delete) {
+    return collapseChanges(changes.slice(1))
+  }
+  // Upsert, Insert
+  if (first.type === Action.Upsert && second.type === Action.Insert) {
+    throw new Error('Cannot insert after upserting the same record, use Upsert')
+  }
+  // Upsert, Update
+  if (first.type === Action.Upsert && second.type === Action.Update) {
+    return collapseChanges([Upsert<T>({...first.data, ...second.data}), ...changes.slice(2)])
+  }
+  // Upsert, Upsert
+  if (first.type === Action.Upsert && second.type === Action.Upsert) {
+    return collapseChanges([Upsert<T>({...first.data, ...second.data}), ...changes.slice(2)])
+  }
+  // Upsert, Delete: We keep the delete
+  if (first.type === Action.Upsert && second.type === Action.Delete) {
+    return collapseChanges(changes.slice(1))
+  }
+  // Delete, Insert: Becomes an update 
+  if (first.type === Action.Delete && second.type === Action.Insert) {
+    return collapseChanges([Update<T, Ids>(second.data), ...changes.slice(2)])
+  }
+  // Delete, Update
+  if (first.type === Action.Delete && second.type === Action.Update) {
+    throw new Error('Cannot update after deleting the same record, use Upsert')
+  }
+  // Delete, Upsert: Keep the upsert
+  if (first.type === Action.Delete && second.type === Action.Upsert) {
+    return collapseChanges(changes.slice(1))
+  }
+  // Delete, Delete: Keep the latter delete
+  if (first.type === Action.Delete && second.type === Action.Delete) {
+    return collapseChanges(changes.slice(1))
+  }
+
+  return []
+}

--- a/packages/projection-pg/src/collapse.ts
+++ b/packages/projection-pg/src/collapse.ts
@@ -8,70 +8,63 @@ export function collapseChanges<T extends Record<string, any>, Ids extends keyof
   const first = changes[0]
   const second = changes[1]
 
-  // Insert, Insert
-  if (first.type === Action.Insert && second.type === Action.Insert) {
-    throw new Error('Cannot insert the same record twice, use Upsert')
+  switch (first.type) {
+    case Action.Insert:
+      switch (second.type) {
+        case Action.Insert:
+          throw new Error("Cannot insert the same record twice, use Upsert")
+        case Action.Update:
+          return collapseChanges([
+            Insert<T>({ ...first.data, ...second.data }),
+            ...changes.slice(2),
+          ])
+        case Action.Upsert:
+          return collapseChanges([Insert({...first.data, ...second.data}), ...changes.slice(2)])
+        case Action.Delete:
+          return collapseChanges(changes.slice(2))
+      }
+    case Action.Update:
+      switch (second.type) {
+        case Action.Insert:
+          throw new Error("Cannot insert after updating the same record, use Upsert")
+        case Action.Update:
+          return collapseChanges([
+            Update<T, Ids>({ ...first.data, ...second.data }),
+            ...changes.slice(2),
+          ])
+        case Action.Upsert:
+          return collapseChanges([second, ...changes.slice(2)])
+        case Action.Delete:
+          return collapseChanges(changes.slice(1))
+      }
+    case Action.Upsert:
+      switch (second.type) {
+        case Action.Insert:
+          throw new Error("Cannot insert after upserting the same record, use Upsert")
+        case Action.Update:
+          return collapseChanges([
+            Upsert<T>({ ...first.data, ...second.data }),
+            ...changes.slice(2),
+          ])
+        case Action.Upsert:
+          return collapseChanges([
+            Upsert<T>({ ...first.data, ...second.data }),
+            ...changes.slice(2),
+          ])
+        case Action.Delete:
+          return collapseChanges(changes.slice(1))
+      }
+    case Action.Delete:
+      switch (second.type) {
+        case Action.Insert:
+          return collapseChanges([Update<T, Ids>(second.data), ...changes.slice(2)])
+        case Action.Update:
+          throw new Error("Cannot update after deleting the same record, use Upsert")
+        case Action.Upsert:
+          return collapseChanges(changes.slice(1))
+        case Action.Delete:
+          return collapseChanges(changes.slice(1))
+      }
   }
-  // Insert, Update
-  if (first.type === Action.Insert && second.type === Action.Update) {
-    return collapseChanges([Insert<T>({ ...first.data, ...second.data }), ...changes.slice(2)])
-  }
-  // Insert, Upsert: Upsert is a full replace so we can just drop the insert
-  if (first.type === Action.Insert && second.type === Action.Upsert) {
-    return collapseChanges([second, ...changes.slice(2)])
-  }
-  // Insert, Delete
-  if (first.type === Action.Insert && second.type === Action.Delete) {
-    return collapseChanges(changes.slice(2))
-  }
-  // Update, Insert
-  if (first.type === Action.Update && second.type === Action.Insert) {
-    throw new Error('Cannot insert after updating the same record, use Upsert')
-  }
-  // Update, Update
-  if (first.type === Action.Update && second.type === Action.Update) {
-    return collapseChanges([Update<T, Ids>({ ...first.data, ...second.data }), ...changes.slice(2)])
-  }
-  // Update, Upsert: Upsert is a full replace so we can just drop the update
-  if (first.type === Action.Update && second.type === Action.Upsert) {
-    return collapseChanges([second, ...changes.slice(2)])
-  }
-  // Update, Delete: Update indicates the record exists, so we can drop the update and keep the delete 
-  if (first.type === Action.Update && second.type === Action.Delete) {
-    return collapseChanges(changes.slice(1))
-  }
-  // Upsert, Insert
-  if (first.type === Action.Upsert && second.type === Action.Insert) {
-    throw new Error('Cannot insert after upserting the same record, use Upsert')
-  }
-  // Upsert, Update
-  if (first.type === Action.Upsert && second.type === Action.Update) {
-    return collapseChanges([Upsert<T>({...first.data, ...second.data}), ...changes.slice(2)])
-  }
-  // Upsert, Upsert
-  if (first.type === Action.Upsert && second.type === Action.Upsert) {
-    return collapseChanges([Upsert<T>({...first.data, ...second.data}), ...changes.slice(2)])
-  }
-  // Upsert, Delete: We keep the delete
-  if (first.type === Action.Upsert && second.type === Action.Delete) {
-    return collapseChanges(changes.slice(1))
-  }
-  // Delete, Insert: Becomes an update 
-  if (first.type === Action.Delete && second.type === Action.Insert) {
-    return collapseChanges([Update<T, Ids>(second.data), ...changes.slice(2)])
-  }
-  // Delete, Update
-  if (first.type === Action.Delete && second.type === Action.Update) {
-    throw new Error('Cannot update after deleting the same record, use Upsert')
-  }
-  // Delete, Upsert: Keep the upsert
-  if (first.type === Action.Delete && second.type === Action.Upsert) {
-    return collapseChanges(changes.slice(1))
-  }
-  // Delete, Delete: Keep the latter delete
-  if (first.type === Action.Delete && second.type === Action.Delete) {
-    return collapseChanges(changes.slice(1))
-  }
-
-  return []
 }
+

--- a/packages/projection-pg/src/collapse.ts
+++ b/packages/projection-pg/src/collapse.ts
@@ -2,14 +2,14 @@ import { Action, Change, Insert, Update, Upsert } from "./types"
 
 // Note: do not run prettier over this file, it does a bad job and makes it harder to read
 
-function concat(a: Change, b: Change): Change {
+function concat(a: Change, b: Change): Change | undefined {
   switch (a.type) {
     case Action.Insert:
       switch (b.type) {
         case Action.Insert: throw new Error("Cannot insert the same record twice, use Upsert")
         case Action.Update:
         case Action.Upsert: return Insert({ ...a.data, ...b.data })
-        case Action.Delete: return b
+        case Action.Delete: return undefined
       }
     case Action.Update:
       switch (b.type) {
@@ -41,7 +41,10 @@ export function collapseChanges(changes: Change[]): Change | undefined {
   let result = changes[0]
 
   for (let i = 1; i < changes.length; i++) {
-    result = concat(result, changes[i])
+    const res = concat(result, changes[i])
+    // an undefined means we've zeroed out the change so we skip
+    if (res == null) { result = changes[i + 1]; i++; continue; }
+    result = res
   }
   return result
 }

--- a/packages/projection-pg/src/collapse.ts
+++ b/packages/projection-pg/src/collapse.ts
@@ -2,8 +2,8 @@ import { Action, Change, Insert, Update, Upsert } from "./types"
 
 export function collapseChanges<T extends Record<string, any>, Ids extends keyof T>(
   changes: Change<T, Ids>[],
-): Change<T, Ids>[] {
-  if (changes.length <= 1) return changes
+): Change<T, Ids> | undefined {
+  if (changes.length <= 1) return changes[0]
 
   const first = changes[0]
   const second = changes[1]

--- a/packages/projection-pg/src/collapse.ts
+++ b/packages/projection-pg/src/collapse.ts
@@ -1,8 +1,6 @@
 import { Action, Change, Insert, Update, Upsert } from "./types"
 
-export function collapseChanges<T extends Record<string, any>, Ids extends keyof T>(
-  changes: Change<T, Ids>[],
-): Change<T, Ids> | undefined {
+export function collapseChanges(changes: Change[]): Change | undefined {
   if (changes.length <= 1) return changes[0]
 
   const first = changes[0]
@@ -15,11 +13,11 @@ export function collapseChanges<T extends Record<string, any>, Ids extends keyof
           throw new Error("Cannot insert the same record twice, use Upsert")
         case Action.Update:
           return collapseChanges([
-            Insert<T>({ ...first.data, ...second.data }),
+            Insert({ ...first.data, ...second.data }),
             ...changes.slice(2),
           ])
         case Action.Upsert:
-          return collapseChanges([Insert({...first.data, ...second.data}), ...changes.slice(2)])
+          return collapseChanges([Insert({ ...first.data, ...second.data }), ...changes.slice(2)])
         case Action.Delete:
           return collapseChanges(changes.slice(2))
       }
@@ -29,7 +27,7 @@ export function collapseChanges<T extends Record<string, any>, Ids extends keyof
           throw new Error("Cannot insert after updating the same record, use Upsert")
         case Action.Update:
           return collapseChanges([
-            Update<T, Ids>({ ...first.data, ...second.data }),
+            Update({ ...first.data, ...second.data }),
             ...changes.slice(2),
           ])
         case Action.Upsert:
@@ -43,12 +41,12 @@ export function collapseChanges<T extends Record<string, any>, Ids extends keyof
           throw new Error("Cannot insert after upserting the same record, use Upsert")
         case Action.Update:
           return collapseChanges([
-            Upsert<T>({ ...first.data, ...second.data }),
+            Upsert({ ...first.data, ...second.data }),
             ...changes.slice(2),
           ])
         case Action.Upsert:
           return collapseChanges([
-            Upsert<T>({ ...first.data, ...second.data }),
+            Upsert({ ...first.data, ...second.data }),
             ...changes.slice(2),
           ])
         case Action.Delete:
@@ -57,7 +55,7 @@ export function collapseChanges<T extends Record<string, any>, Ids extends keyof
     case Action.Delete:
       switch (second.type) {
         case Action.Insert:
-          return collapseChanges([Update<T, Ids>(second.data), ...changes.slice(2)])
+          return collapseChanges([Update(second.data), ...changes.slice(2)])
         case Action.Update:
           throw new Error("Cannot update after deleting the same record, use Upsert")
         case Action.Upsert:
@@ -67,4 +65,3 @@ export function collapseChanges<T extends Record<string, any>, Ids extends keyof
       }
   }
 }
-

--- a/packages/projection-pg/src/index.ts
+++ b/packages/projection-pg/src/index.ts
@@ -1,0 +1,2 @@
+export * from './projection.js'
+export * from './types.js'

--- a/packages/projection-pg/src/projection.ts
+++ b/packages/projection-pg/src/projection.ts
@@ -1,0 +1,61 @@
+import { ITimelineEvent } from "@equinox-js/core"
+import createKnex from "knex"
+import { Pool } from "pg"
+import { collapseChanges } from "./collapse"
+import { Action, Change } from "./types"
+
+// instantiate knex without a db connection since we're only using it for query building
+const knex = createKnex({ client: "pg" })
+
+// prettier-ignore: no new lines please
+export class Projection<T extends Record<string, any>, Ids extends keyof T> {
+  constructor(
+    private readonly table: string,
+    private readonly idColumns: Ids[],
+    private readonly schema = "public",
+  ) {}
+
+  changeToQuery(change: Change<T, Ids>) {
+    const qb = knex.table(this.table).withSchema(this.schema)
+    switch (change.type) {
+      case Action.Update:
+        return qb
+          .where(Object.fromEntries(this.idColumns.map((col) => [col, change.data[col]])))
+          .update(change.data)
+      case Action.Insert:
+        return qb.insert(change.data)
+      case Action.Delete:
+        return qb.where(change.data).delete()
+      case Action.Upsert:
+        return qb
+          .insert(change.data)
+          .onConflict(this.idColumns as string[])
+          .merge()
+    }
+  }
+
+  async execute(pool: Pool, changes: Change<T, Ids>[]) {
+    const conn = await pool.connect()
+    try {
+      await conn.query("BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE")
+      for (const change of changes) {
+        const query = this.changeToQuery(change)
+        const native = query.toSQL().toNative()
+        await conn.query(native.sql, native.bindings as any[])
+      }
+      await conn.query("COMMIT")
+    } finally {
+      conn.release()
+    }
+  }
+
+  createHandler(
+    pool: Pool,
+    changes: (stream: string, events: ITimelineEvent<string>) => Change<T, Ids>[],
+  ) {
+    return (stream: string, events: ITimelineEvent<string>[]) => {
+      const changeset = collapseChanges(events.flatMap((event) => changes(stream, event)))
+      return this.execute(pool, changeset)
+    }
+  }
+}

--- a/packages/projection-pg/src/types.ts
+++ b/packages/projection-pg/src/types.ts
@@ -5,23 +5,16 @@ export enum Action {
   Upsert,
 }
 
-export type Change<T extends Record<string, any>, Ids extends keyof T> =
-  | { type: Action.Update; data: Pick<T, Ids> & Partial<T> }
+type Item = Record<string, any>
+
+export type Change<T extends Item = Item> =
   | { type: Action.Insert; data: T }
-  | { type: Action.Delete; data: Pick<T, Ids> }
+  | { type: Action.Update; data: Partial<T> }
+  | { type: Action.Delete; data: Partial<T> }
   | { type: Action.Upsert; data: T }
 
-export const Update = <T extends Record<string, any>, Ids extends keyof T>(
-  data: Pick<T, Ids> & Partial<T>,
-): Change<T, Ids> => ({ type: Action.Update, data })
-export const Insert = <T extends Record<string, any>>(data: T): Change<T, keyof T> => ({
-  type: Action.Insert,
-  data,
-})
-export const Delete = <T extends Record<string, any>, Ids extends keyof T>(
-  data: Pick<T, Ids>,
-): Change<T, Ids> => ({ type: Action.Delete, data })
-export const Upsert = <T extends Record<string, any>>(data: T): Change<T, keyof T> => ({
-  type: Action.Upsert,
-  data,
-})
+export const Insert = <T extends Item>(data: T): Change<T> => ({ type: Action.Insert, data })
+export const Update = <T extends Item>(data: Partial<T>): Change<T> => ({ type: Action.Update, data })
+export const Delete = <T extends Item>(data: Partial<T>): Change<T> => ({ type: Action.Delete, data })
+export const Upsert = <T extends Item>(data: T): Change<T> => ({ type: Action.Upsert, data })
+

--- a/packages/projection-pg/src/types.ts
+++ b/packages/projection-pg/src/types.ts
@@ -7,14 +7,22 @@ export enum Action {
 
 type Item = Record<string, any>
 
-export type Change<T extends Item = Item> =
-  | { type: Action.Insert; data: T }
-  | { type: Action.Update; data: Partial<T> }
-  | { type: Action.Delete; data: Partial<T> }
-  | { type: Action.Upsert; data: T }
+export type Change =
+  | { type: Action.Insert; data: Item }
+  | { type: Action.Update; data: Item }
+  | { type: Action.Delete; data: Item }
+  | { type: Action.Upsert; data: Item }
 
-export const Insert = <T extends Item>(data: T): Change<T> => ({ type: Action.Insert, data })
-export const Update = <T extends Item>(data: Partial<T>): Change<T> => ({ type: Action.Update, data })
-export const Delete = <T extends Item>(data: Partial<T>): Change<T> => ({ type: Action.Delete, data })
-export const Upsert = <T extends Item>(data: T): Change<T> => ({ type: Action.Upsert, data })
+export const Insert = (data: Item): Change => ({ type: Action.Insert, data })
+export const Update = (data: Item): Change => ({ type: Action.Update, data })
+export const Delete = (data: Item): Change => ({ type: Action.Delete, data })
+export const Upsert = (data: Item): Change => ({ type: Action.Upsert, data })
 
+export const forEntity = <T extends Item, Id extends keyof T>() => {
+  const Insert = (data: T): Change => ({ type: Action.Insert, data })
+  const Update = (data: Pick<T, Id> & Partial<T>): Change => ({ type: Action.Update, data })
+  const Delete = (data: Pick<T, Id> & Partial<T>): Change => ({ type: Action.Delete, data })
+  const Upsert = (data: T): Change => ({ type: Action.Upsert, data })
+
+  return { Insert, Update, Delete, Upsert }
+}

--- a/packages/projection-pg/src/types.ts
+++ b/packages/projection-pg/src/types.ts
@@ -1,6 +1,6 @@
 export enum Action {
-  Update,
   Insert,
+  Update,
   Delete,
   Upsert,
 }

--- a/packages/projection-pg/src/types.ts
+++ b/packages/projection-pg/src/types.ts
@@ -18,10 +18,10 @@ export const Update = (data: Item): Change => ({ type: Action.Update, data })
 export const Delete = (data: Item): Change => ({ type: Action.Delete, data })
 export const Upsert = (data: Item): Change => ({ type: Action.Upsert, data })
 
-export const forEntity = <T extends Item, Id extends keyof T>() => {
+export const forEntity = <T extends Item, RequiredKeys extends keyof T>() => {
   const Insert = (data: T): Change => ({ type: Action.Insert, data })
-  const Update = (data: Pick<T, Id> & Partial<T>): Change => ({ type: Action.Update, data })
-  const Delete = (data: Pick<T, Id> & Partial<T>): Change => ({ type: Action.Delete, data })
+  const Update = (data: Pick<T, RequiredKeys> & Partial<T>): Change => ({ type: Action.Update, data })
+  const Delete = (data: Pick<T, RequiredKeys> & Partial<T>): Change => ({ type: Action.Delete, data })
   const Upsert = (data: T): Change => ({ type: Action.Upsert, data })
 
   return { Insert, Update, Delete, Upsert }

--- a/packages/projection-pg/src/types.ts
+++ b/packages/projection-pg/src/types.ts
@@ -1,0 +1,27 @@
+export enum Action {
+  Update,
+  Insert,
+  Delete,
+  Upsert,
+}
+
+export type Change<T extends Record<string, any>, Ids extends keyof T> =
+  | { type: Action.Update; data: Pick<T, Ids> & Partial<T> }
+  | { type: Action.Insert; data: T }
+  | { type: Action.Delete; data: Pick<T, Ids> }
+  | { type: Action.Upsert; data: T }
+
+export const Update = <T extends Record<string, any>, Ids extends keyof T>(
+  data: Pick<T, Ids> & Partial<T>,
+): Change<T, Ids> => ({ type: Action.Update, data })
+export const Insert = <T extends Record<string, any>>(data: T): Change<T, keyof T> => ({
+  type: Action.Insert,
+  data,
+})
+export const Delete = <T extends Record<string, any>, Ids extends keyof T>(
+  data: Pick<T, Ids>,
+): Change<T, Ids> => ({ type: Action.Delete, data })
+export const Upsert = <T extends Record<string, any>>(data: T): Change<T, keyof T> => ({
+  type: Action.Upsert,
+  data,
+})

--- a/packages/projection-pg/test/collapse.test.ts
+++ b/packages/projection-pg/test/collapse.test.ts
@@ -9,7 +9,7 @@ describe("Collapsing changesets", () => {
       Update({ id: 1, name: "bob", age: 31 }),
       Delete({ id: 1 }),
     ]
-    expect(collapseChanges(changes)).toEqual([])
+    expect(collapseChanges(changes)).toEqual(undefined)
   })
 
   test("Inserting with updates", () => {
@@ -18,7 +18,7 @@ describe("Collapsing changesets", () => {
       Update({ id: 1, name: "bobby", age: 31 }),
       Update({ id: 1, age: 32 }),
     ]
-    expect(collapseChanges(changes)).toEqual([Insert({ id: 1, name: "bobby", age: 32 })])
+    expect(collapseChanges(changes)).toEqual(Insert({ id: 1, name: "bobby", age: 32 }))
   })
 
   test("Inserting with delete and another insert", () => {
@@ -27,7 +27,7 @@ describe("Collapsing changesets", () => {
       Delete({ id: 1 }),
       Insert({ id: 1, name: "bobby", age: 31 }),
     ]
-    expect(collapseChanges(changes)).toEqual([Insert({ id: 1, name: "bobby", age: 31 })])
+    expect(collapseChanges(changes)).toEqual(Insert({ id: 1, name: "bobby", age: 31 }))
   })
 
   test("Upserts", () => {
@@ -35,7 +35,7 @@ describe("Collapsing changesets", () => {
       Upsert({ id: 1, name: "bob", age: 30 }),
       Upsert({ id: 1, name: "bobby", age: 31 }),
     ]
-    expect(collapseChanges(changes)).toEqual([Upsert({ id: 1, name: "bobby", age: 31 })])
+    expect(collapseChanges(changes)).toEqual(Upsert({ id: 1, name: "bobby", age: 31 }))
   })
 
   test("Upsert with deletes", () => {
@@ -44,7 +44,7 @@ describe("Collapsing changesets", () => {
       Delete({ id: 1 }),
       Upsert({ id: 1, name: "bobby", age: 31 }),
     ]
-    expect(collapseChanges(changes)).toEqual([Upsert({ id: 1, name: "bobby", age: 31 })])
+    expect(collapseChanges(changes)).toEqual(Upsert({ id: 1, name: "bobby", age: 31 }))
   })
 
   test("The whole shebang", () => {
@@ -56,6 +56,6 @@ describe("Collapsing changesets", () => {
       Upsert({ id: 1, name: "bobby", age: 33 }),
       Update({ id: 1, name: "blob" }),
     ]
-    expect(collapseChanges(changes)).toEqual([Insert({ id: 1, name: "blob", age: 33 })])
+    expect(collapseChanges(changes)).toEqual(Insert({ id: 1, name: "blob", age: 33 }))
   })
 })

--- a/packages/projection-pg/test/collapse.test.ts
+++ b/packages/projection-pg/test/collapse.test.ts
@@ -56,6 +56,6 @@ describe("Collapsing changesets", () => {
       Upsert({ id: 1, name: "bobby", age: 33 }),
       Update({ id: 1, name: "blob" }),
     ]
-    expect(collapseChanges(changes)).toEqual([Upsert({ id: 1, name: "blob", age: 33 })])
+    expect(collapseChanges(changes)).toEqual([Insert({ id: 1, name: "blob", age: 33 })])
   })
 })

--- a/packages/projection-pg/test/collapse.test.ts
+++ b/packages/projection-pg/test/collapse.test.ts
@@ -1,0 +1,61 @@
+import { describe, test, expect } from "vitest"
+import { collapseChanges } from "../src/collapse.js"
+import { Delete, Insert, Update, Upsert } from "../src/index.js"
+
+describe("Collapsing changesets", () => {
+  test("Deleting in the same changeset as inserting", () => {
+    const changes = [
+      Insert({ id: 1, name: "bob", age: 30 }),
+      Update({ id: 1, name: "bob", age: 31 }),
+      Delete({ id: 1 }),
+    ]
+    expect(collapseChanges(changes)).toEqual([])
+  })
+
+  test("Inserting with updates", () => {
+    const changes = [
+      Insert({ id: 1, name: "bob", age: 30 }),
+      Update({ id: 1, name: "bobby", age: 31 }),
+      Update({ id: 1, age: 32 }),
+    ]
+    expect(collapseChanges(changes)).toEqual([Insert({ id: 1, name: "bobby", age: 32 })])
+  })
+
+  test("Inserting with delete and another insert", () => {
+    const changes = [
+      Insert({ id: 1, name: "bob", age: 30 }),
+      Delete({ id: 1 }),
+      Insert({ id: 1, name: "bobby", age: 31 }),
+    ]
+    expect(collapseChanges(changes)).toEqual([Insert({ id: 1, name: "bobby", age: 31 })])
+  })
+
+  test("Upserts", () => {
+    const changes = [
+      Upsert({ id: 1, name: "bob", age: 30 }),
+      Upsert({ id: 1, name: "bobby", age: 31 }),
+    ]
+    expect(collapseChanges(changes)).toEqual([Upsert({ id: 1, name: "bobby", age: 31 })])
+  })
+
+  test("Upsert with deletes", () => {
+    const changes = [
+      Upsert({ id: 1, name: "bob", age: 30 }),
+      Delete({ id: 1 }),
+      Upsert({ id: 1, name: "bobby", age: 31 }),
+    ]
+    expect(collapseChanges(changes)).toEqual([Upsert({ id: 1, name: "bobby", age: 31 })])
+  })
+
+  test("The whole shebang", () => {
+    const changes = [
+      Insert({ id: 1, name: "bob", age: 30 }),
+      Update({ id: 1, name: "bobby", age: 31 }),
+      Delete({ id: 1 }),
+      Insert({ id: 1, name: "bobby", age: 32 }),
+      Upsert({ id: 1, name: "bobby", age: 33 }),
+      Update({ id: 1, name: "blob" }),
+    ]
+    expect(collapseChanges(changes)).toEqual([Upsert({ id: 1, name: "blob", age: 33 })])
+  })
+})

--- a/packages/projection-pg/test/view-data.test.ts
+++ b/packages/projection-pg/test/view-data.test.ts
@@ -1,0 +1,101 @@
+import { randomUUID } from "crypto"
+import { Pool } from "pg"
+import { describe, test, expect, beforeAll } from "vitest"
+import { Delete, Insert, Update, Upsert, Projection } from "../src/index.js"
+
+const pool = new Pool({
+  connectionString:
+    process.env.DATABASE_URL ?? "postgres://postgres:postgres@localhost:5432/postgres",
+})
+
+describe("User table", () => {
+  beforeAll(async () => {
+    await pool.query(
+      `create table if not exists view_data_test (
+      id uuid not null primary key,
+      name text not null,
+      age int not null
+    )`,
+    )
+  })
+
+  const projection = new Projection("view_data_test", ["id"])
+
+  test("Insert", async () => {
+    const id = randomUUID()
+    await projection.execute(pool, [Insert({ id, name: "bob", age: 30 })])
+    const { rows } = await pool.query("select * from view_data_test where id = $1", [id])
+    expect(rows).toEqual([{ id, name: "bob", age: 30 }])
+  })
+  test("Update", async () => {
+    const id = randomUUID()
+    await projection.execute(pool, [Insert({ id, name: "bob", age: 30 })])
+    await projection.execute(pool, [Update({ id, name: "bob", age: 31 })])
+    const { rows } = await pool.query("select * from view_data_test where id = $1", [id])
+    expect(rows).toEqual([{ id, name: "bob", age: 31 }])
+  })
+  test("Delete", async () => {
+    const id = randomUUID()
+    await projection.execute(pool, [Insert({ id, name: "bob", age: 30 })])
+    await projection.execute(pool, [Delete({ id })])
+    const { rows } = await pool.query("select * from view_data_test where id = $1", [id])
+    expect(rows).toEqual([])
+  })
+
+  test("Upsert", async () => {
+    const id = randomUUID()
+    await projection.execute(pool, [Upsert({ id, name: "bob", age: 30 })])
+    await projection.execute(pool, [Upsert({ id, name: "bob", age: 31 })])
+    const { rows } = await pool.query("select * from view_data_test where id = $1", [id])
+    expect(rows).toEqual([{ id, name: "bob", age: 31 }])
+  })
+})
+
+describe("Composite primary key", () => {
+  beforeAll(async () => {
+    await pool.query(
+      `create table if not exists view_data_composite_key (
+      id uuid not null,
+      tenant_id uuid not null,
+      name text not null,
+      age int not null,
+      primary key (id, tenant_id)
+    )`,
+    )
+  })
+
+  const projection = new Projection("view_data_composite_key", ["id", "tenant_id"])
+
+  test("Insert", async () => {
+    const id = randomUUID()
+    const tenant_id = randomUUID()
+    await projection.execute(pool, [Insert({ id, tenant_id, name: "bob", age: 30 })])
+    const { rows } = await pool.query("select * from view_data_composite_key where id = $1", [id])
+    expect(rows).toEqual([{ id, tenant_id, name: "bob", age: 30 }])
+  })
+  test("Update", async () => {
+    const id = randomUUID()
+    const tenant_id = randomUUID()
+    await projection.execute(pool, [Insert({ id, tenant_id, name: "bob", age: 30 })])
+    await projection.execute(pool, [Update({ id, tenant_id, name: "bob", age: 31 })])
+    const { rows } = await pool.query("select * from view_data_composite_key where id = $1", [id])
+    expect(rows).toEqual([{ id, tenant_id, name: "bob", age: 31 }])
+  })
+  test("Delete", async () => {
+    const id = randomUUID()
+    const tenant_id = randomUUID()
+    await projection.execute(pool, [Insert({ id, tenant_id, name: "bob", age: 30 })])
+    await projection.execute(pool, [Delete({ id, tenant_id })])
+    const { rows } = await pool.query("select * from view_data_composite_key where id = $1", [id])
+    expect(rows).toEqual([])
+  })
+
+  test("Upsert", async () => {
+    const id = randomUUID()
+    const tenant_id = randomUUID()
+    await projection.execute(pool, [Upsert({ id, tenant_id, name: "bob", age: 30 })])
+    await projection.execute(pool, [Upsert({ id, tenant_id, name: "bob", age: 31 })])
+    const { rows } = await pool.query("select * from view_data_composite_key where id = $1", [id])
+    expect(rows).toEqual([{ id, tenant_id, name: "bob", age: 31 }])
+  })
+})

--- a/packages/projection-pg/test/view-data.test.ts
+++ b/packages/projection-pg/test/view-data.test.ts
@@ -23,69 +23,69 @@ describe("User table", () => {
 
   test("Insert", async () => {
     const id = randomUUID()
-    await projection.execute(pool, [Insert({ id, name: "bob", age: 30 })])
+    await projection.execute(pool, Insert({ id, name: "bob", age: 30 }))
     const { rows } = await pool.query("select * from view_data_test where id = $1", [id])
     expect(rows).toEqual([{ id, name: "bob", age: 30 }])
   })
   test("Update", async () => {
     const id = randomUUID()
-    await projection.execute(pool, [Insert({ id, name: "bob", age: 30 })])
-    await projection.execute(pool, [Update({ id, name: "bob", age: 31 })])
+    await projection.execute(pool, Insert({ id, name: "bob", age: 30 }))
+    await projection.execute(pool, Update({ id, name: "bob", age: 31 }))
     const { rows } = await pool.query("select * from view_data_test where id = $1", [id])
     expect(rows).toEqual([{ id, name: "bob", age: 31 }])
   })
   test("Delete", async () => {
     const id = randomUUID()
-    await projection.execute(pool, [Insert({ id, name: "bob", age: 30 })])
-    await projection.execute(pool, [Delete({ id })])
+    await projection.execute(pool, Insert({ id, name: "bob", age: 30 }))
+    await projection.execute(pool, Delete({ id }))
     const { rows } = await pool.query("select * from view_data_test where id = $1", [id])
     expect(rows).toEqual([])
   })
 
   test("Upsert", async () => {
     const id = randomUUID()
-    await projection.execute(pool, [Upsert({ id, name: "bob", age: 30 })])
-    await projection.execute(pool, [Upsert({ id, name: "bob", age: 31 })])
+    await projection.execute(pool, Upsert({ id, name: "bob", age: 30 }))
+    await projection.execute(pool, Upsert({ id, name: "bob", age: 31 }))
     const { rows } = await pool.query("select * from view_data_test where id = $1", [id])
     expect(rows).toEqual([{ id, name: "bob", age: 31 }])
   })
 })
 
-describe("Composite primary key", () => {
-  beforeAll(async () => {
-    await pool.query(
-      `create table if not exists view_data_composite_key (
+beforeAll(async () => {
+  await pool.query(
+    `create table if not exists view_data_composite_key (
       id uuid not null,
       tenant_id uuid not null,
       name text not null,
       age int not null,
       primary key (id, tenant_id)
     )`,
-    )
-  })
+  )
+})
 
+describe("Composite primary key", () => {
   const projection = new Projection("view_data_composite_key", ["id", "tenant_id"])
 
   test("Insert", async () => {
     const id = randomUUID()
     const tenant_id = randomUUID()
-    await projection.execute(pool, [Insert({ id, tenant_id, name: "bob", age: 30 })])
+    await projection.execute(pool, Insert({ id, tenant_id, name: "bob", age: 30 }))
     const { rows } = await pool.query("select * from view_data_composite_key where id = $1", [id])
     expect(rows).toEqual([{ id, tenant_id, name: "bob", age: 30 }])
   })
   test("Update", async () => {
     const id = randomUUID()
     const tenant_id = randomUUID()
-    await projection.execute(pool, [Insert({ id, tenant_id, name: "bob", age: 30 })])
-    await projection.execute(pool, [Update({ id, tenant_id, name: "bob", age: 31 })])
+    await projection.execute(pool, Insert({ id, tenant_id, name: "bob", age: 30 }))
+    await projection.execute(pool, Update({ id, tenant_id, name: "bob", age: 31 }))
     const { rows } = await pool.query("select * from view_data_composite_key where id = $1", [id])
     expect(rows).toEqual([{ id, tenant_id, name: "bob", age: 31 }])
   })
   test("Delete", async () => {
     const id = randomUUID()
     const tenant_id = randomUUID()
-    await projection.execute(pool, [Insert({ id, tenant_id, name: "bob", age: 30 })])
-    await projection.execute(pool, [Delete({ id, tenant_id })])
+    await projection.execute(pool, Insert({ id, tenant_id, name: "bob", age: 30 }))
+    await projection.execute(pool, Delete({ id, tenant_id }))
     const { rows } = await pool.query("select * from view_data_composite_key where id = $1", [id])
     expect(rows).toEqual([])
   })
@@ -93,9 +93,27 @@ describe("Composite primary key", () => {
   test("Upsert", async () => {
     const id = randomUUID()
     const tenant_id = randomUUID()
-    await projection.execute(pool, [Upsert({ id, tenant_id, name: "bob", age: 30 })])
-    await projection.execute(pool, [Upsert({ id, tenant_id, name: "bob", age: 31 })])
+    await projection.execute(pool, Upsert({ id, tenant_id, name: "bob", age: 30 }))
+    await projection.execute(pool, Upsert({ id, tenant_id, name: "bob", age: 31 }))
     const { rows } = await pool.query("select * from view_data_composite_key where id = $1", [id])
     expect(rows).toEqual([{ id, tenant_id, name: "bob", age: 31 }])
+  })
+})
+
+describe("handler", () => {
+  const projection = new Projection("view_data_composite_key", ["id", "tenant_id"])
+
+  test('Collapses', async () => {
+    const id = randomUUID()
+    const tenant_id = randomUUID()
+    const handler = projection.createHandler(pool, () => [
+      Insert({ id, tenant_id, name: "bob", age: 30 }),
+      Update({ id, tenant_id, name: "bobby" }),
+      Update({ id, tenant_id, age: 111 }),
+    ])
+                                             
+    await handler(undefined, [])
+    const { rows } = await pool.query("select * from view_data_composite_key where id = $1", [id])
+    expect(rows).toEqual([{ id, tenant_id, name: "bobby", age: 111 }])
   })
 })

--- a/packages/projection-pg/tsconfig.json
+++ b/packages/projection-pg/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "tsconfig/base.json",
+  "exclude": ["node_modules"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -313,9 +313,6 @@ importers:
       '@equinox-js/core':
         specifier: workspace:*
         version: link:../core
-      '@opentelemetry/api':
-        specifier: ^1.4.0
-        version: 1.4.0
       knex:
         specifier: ^2.5.1
         version: 2.5.1(pg@8.8.0)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,6 +33,9 @@ importers:
       '@equinox-js/message-db-consumer':
         specifier: workspace:*
         version: link:../../packages/message-db-consumer
+      '@equinox-js/projection-pg':
+        specifier: workspace:*
+        version: link:../../packages/projection-pg
       '@honeycombio/opentelemetry-node':
         specifier: ^0.5.0
         version: 0.5.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -305,6 +305,43 @@ importers:
         specifier: ^4.7.4
         version: 4.9.5
 
+  packages/projection-pg:
+    dependencies:
+      '@equinox-js/core':
+        specifier: workspace:*
+        version: link:../core
+      '@opentelemetry/api':
+        specifier: ^1.4.0
+        version: 1.4.0
+      knex:
+        specifier: ^2.5.1
+        version: 2.5.1(pg@8.8.0)
+      pg:
+        specifier: ^8.8.0
+        version: 8.8.0
+    devDependencies:
+      '@types/knex':
+        specifier: ^0.16.1
+        version: 0.16.1(pg@8.8.0)
+      '@types/node':
+        specifier: ^18.11.18
+        version: 18.11.18
+      '@types/pg':
+        specifier: ^8.6.6
+        version: 8.6.6
+      tsconfig:
+        specifier: workspace:*
+        version: link:../tsconfig
+      tsup:
+        specifier: ^6.5.0
+        version: 6.5.0(typescript@4.9.5)
+      typescript:
+        specifier: ^4.7.4
+        version: 4.9.5
+      vitest:
+        specifier: ^0.25.3
+        version: 0.25.8
+
   packages/tsconfig: {}
 
 packages:
@@ -3148,7 +3185,7 @@ packages:
     resolution: {integrity: sha512-kopW4ZEKX2mgaPi9jh3lTP+2ixbe0z+tAEOn3v0ZM6jzQl7z+2C1ZZjU1cVYbX+RDGqu7n6BMyv5wmWuqiuKYQ==}
     engines: {node: '>=14'}
     dependencies:
-      '@opentelemetry/api': 1.4.0
+      '@opentelemetry/api': 1.4.1
       tslib: 2.4.1
     dev: false
 
@@ -4423,6 +4460,22 @@ packages:
       '@types/node': 18.11.18
     dev: false
 
+  /@types/knex@0.16.1(pg@8.8.0):
+    resolution: {integrity: sha512-54gWD1HWwdVx5iLHaJ1qxH3I6KyBsj5fFqzRpXFn7REWiEB2jwspeVCombNsocSrqPd7IRPqKrsIME7/cD+TFQ==}
+    deprecated: This is a stub types definition. knex provides its own type definitions, so you do not need this installed.
+    dependencies:
+      knex: 2.5.1(pg@8.8.0)
+    transitivePeerDependencies:
+      - better-sqlite3
+      - mysql
+      - mysql2
+      - pg
+      - pg-native
+      - sqlite3
+      - supports-color
+      - tedious
+    dev: true
+
   /@types/long@4.0.2:
     resolution: {integrity: sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==}
     dev: false
@@ -5098,7 +5151,6 @@ packages:
   /buffer-writer@2.0.0:
     resolution: {integrity: sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw==}
     engines: {node: '>=4'}
-    dev: false
 
   /bufrw@1.3.0:
     resolution: {integrity: sha512-jzQnSbdJqhIltU9O5KUiTtljP9ccw2u5ix59McQy4pV2xGhVLhRZIndY8GIrgh5HjXa6+QJ9AQhOd2QWQizJFQ==}
@@ -5392,7 +5444,6 @@ packages:
 
   /colorette@2.0.19:
     resolution: {integrity: sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==}
-    dev: false
 
   /combine-promises@1.1.0:
     resolution: {integrity: sha512-ZI9jvcLDxqwaXEixOhArm3r7ReIivsXkpbyEWyeOhzz1QS0iSgBPnWvEqvIQtYyamGCYA88gFhmUrs9hrrQ0pg==}
@@ -5409,6 +5460,10 @@ packages:
   /comma-separated-tokens@1.0.8:
     resolution: {integrity: sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw==}
     dev: false
+
+  /commander@10.0.1:
+    resolution: {integrity: sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==}
+    engines: {node: '>=14'}
 
   /commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
@@ -6378,6 +6433,10 @@ packages:
       esrecurse: 4.3.0
       estraverse: 4.3.0
 
+  /esm@3.2.25:
+    resolution: {integrity: sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==}
+    engines: {node: '>=6'}
+
   /esprima@4.0.1:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
     engines: {node: '>=4'}
@@ -6775,6 +6834,10 @@ packages:
     resolution: {integrity: sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g==}
     dev: false
 
+  /get-package-type@0.1.0:
+    resolution: {integrity: sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==}
+    engines: {node: '>=8.0.0'}
+
   /get-port@7.0.0:
     resolution: {integrity: sha512-mDHFgApoQd+azgMdwylJrv2DX47ywGq1i5VFJE7fZ0dttNq3iQMfsU4IvEgBHojA3KqEudyu7Vq+oN8kNaNkWw==}
     engines: {node: '>=16'}
@@ -6797,6 +6860,9 @@ packages:
   /get-stream@6.0.1:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
     engines: {node: '>=10'}
+
+  /getopts@2.3.0:
+    resolution: {integrity: sha512-5eDf9fuSXwxBL6q5HX+dhDj+dslFGWzU5thZ9kNKUkcPtaPdatmUFKwHFrLb/uf/WpA4BHET+AX3Scl56cAjpA==}
 
   /github-slugger@1.5.0:
     resolution: {integrity: sha512-wIh+gKBI9Nshz2o46B0B3f5k/W+WI9ZAv6y5Dn5WJ5SK1t0TnDimB4WE5rmTD05ZAIn8HALCZVmCsvj0w0v0lw==}
@@ -7299,6 +7365,10 @@ packages:
     engines: {node: '>= 0.10'}
     dev: false
 
+  /interpret@2.2.0:
+    resolution: {integrity: sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==}
+    engines: {node: '>= 0.10'}
+
   /invariant@2.2.4:
     resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
     dependencies:
@@ -7623,6 +7693,52 @@ packages:
     engines: {node: '>= 8'}
     dev: false
 
+  /knex@2.5.1(pg@8.8.0):
+    resolution: {integrity: sha512-z78DgGKUr4SE/6cm7ku+jHvFT0X97aERh/f0MUKAKgFnwCYBEW4TFBqtHWFYiJFid7fMrtpZ/gxJthvz5mEByA==}
+    engines: {node: '>=12'}
+    hasBin: true
+    peerDependencies:
+      better-sqlite3: '*'
+      mysql: '*'
+      mysql2: '*'
+      pg: '*'
+      pg-native: '*'
+      sqlite3: '*'
+      tedious: '*'
+    peerDependenciesMeta:
+      better-sqlite3:
+        optional: true
+      mysql:
+        optional: true
+      mysql2:
+        optional: true
+      pg:
+        optional: true
+      pg-native:
+        optional: true
+      sqlite3:
+        optional: true
+      tedious:
+        optional: true
+    dependencies:
+      colorette: 2.0.19
+      commander: 10.0.1
+      debug: 4.3.4
+      escalade: 3.1.1
+      esm: 3.2.25
+      get-package-type: 0.1.0
+      getopts: 2.3.0
+      interpret: 2.2.0
+      lodash: 4.17.21
+      pg: 8.8.0
+      pg-connection-string: 2.6.1
+      rechoir: 0.8.0
+      resolve-from: 5.0.0
+      tarn: 3.0.2
+      tildify: 2.0.0
+    transitivePeerDependencies:
+      - supports-color
+
   /latest-version@5.1.0:
     resolution: {integrity: sha512-weT+r0kTkRQdCdYCNtkMwWXQTMEswKrFBkm4ckQOMVhhqhIMI1UT2hMj+1iigIhgSZm5gTmrRXBNoGUgaTY1xA==}
     engines: {node: '>=8'}
@@ -7725,7 +7841,6 @@ packages:
 
   /lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
-    dev: false
 
   /long@2.4.0:
     resolution: {integrity: sha512-ijUtjmO/n2A5PaosNG9ZGDsQ3vxJg7ZW8vsY8Kp0f2yIZWhSJvjmegV7t+9RPQKxKrvj8yKGehhS+po14hPLGQ==}
@@ -8197,7 +8312,6 @@ packages:
 
   /packet-reader@1.0.0:
     resolution: {integrity: sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ==}
-    dev: false
 
   /param-case@3.0.4:
     resolution: {integrity: sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==}
@@ -8313,9 +8427,8 @@ packages:
   /pathval@1.1.1:
     resolution: {integrity: sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==}
 
-  /pg-connection-string@2.5.0:
-    resolution: {integrity: sha512-r5o/V/ORTA6TmUnyWZR9nCj1klXCO2CEKNRlVuJptZe85QuhFayC7WeMic7ndayT5IRIR0S0xFxFi2ousartlQ==}
-    dev: false
+  /pg-connection-string@2.6.1:
+    resolution: {integrity: sha512-w6ZzNu6oMmIzEAYVw+RLK0+nqHPt8K3ZnknKi+g48Ak2pr3dtljJW3o+D/n2zzCG07Zoe9VOX3aiKpj+BN0pjg==}
 
   /pg-int8@1.0.1:
     resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
@@ -8327,7 +8440,6 @@ packages:
       pg: '>=8.0'
     dependencies:
       pg: 8.8.0
-    dev: false
 
   /pg-protocol@1.5.0:
     resolution: {integrity: sha512-muRttij7H8TqRNu/DxrAJQITO4Ac7RmX3Klyr/9mJEOBeIpgnF8f9jAfRz5d3XwQZl5qBjF9gLsUtMPJE0vezQ==}
@@ -8353,18 +8465,16 @@ packages:
     dependencies:
       buffer-writer: 2.0.0
       packet-reader: 1.0.0
-      pg-connection-string: 2.5.0
+      pg-connection-string: 2.6.1
       pg-pool: 3.5.2(pg@8.8.0)
       pg-protocol: 1.5.0
       pg-types: 2.2.0
       pgpass: 1.0.5
-    dev: false
 
   /pgpass@1.0.5:
     resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}
     dependencies:
       split2: 4.1.0
-    dev: false
 
   /picocolors@1.0.0:
     resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==}
@@ -9253,6 +9363,12 @@ packages:
       resolve: 1.22.1
     dev: false
 
+  /rechoir@0.8.0:
+    resolution: {integrity: sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==}
+    engines: {node: '>= 10.13.0'}
+    dependencies:
+      resolve: 1.22.1
+
   /recursive-readdir@2.2.3:
     resolution: {integrity: sha512-8HrF5ZsXk5FAH9dgsx3BlUer73nIhuj+9OrQwEbLTPOBzGkL1lsFCR01am+v+0m2Cmbs1nP12hLDl5FA7EszKA==}
     engines: {node: '>=6.0.0'}
@@ -9424,7 +9540,6 @@ packages:
   /resolve-from@5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
-    dev: true
 
   /resolve-pathname@3.0.0:
     resolution: {integrity: sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng==}
@@ -9460,20 +9575,12 @@ packages:
       glob: 7.2.3
     dev: false
 
-  /rollup@3.10.1:
-    resolution: {integrity: sha512-3Er+yel3bZbZX1g2kjVM+FW+RUWDxbG87fcqFM5/9HbPCTpbVp6JOLn7jlxnNlbu7s/N/uDA4EV/91E2gWnxzw==}
-    engines: {node: '>=14.18.0', npm: '>=8.0.0'}
-    hasBin: true
-    optionalDependencies:
-      fsevents: 2.3.2
-
   /rollup@3.26.3:
     resolution: {integrity: sha512-7Tin0C8l86TkpcMtXvQu6saWH93nhG3dGQ1/+l5V2TDMceTxO7kDiK6GzbfLWNNxqJXm591PcEZUozZm51ogwQ==}
     engines: {node: '>=14.18.0', npm: '>=8.0.0'}
     hasBin: true
     optionalDependencies:
       fsevents: 2.3.2
-    dev: true
 
   /rtl-detect@1.0.4:
     resolution: {integrity: sha512-EBR4I2VDSSYr7PkBmFy04uhycIpDKp+21p/jARYXlCSjQksTBQcJ0HFUPOO79EPPH5JS6VAhiIQbycf0O3JAxQ==}
@@ -9832,7 +9939,6 @@ packages:
   /split2@4.1.0:
     resolution: {integrity: sha512-VBiJxFkxiXRlUIeyMQi8s4hgvKCSjtknJv/LVYbrgALPwf5zSKmEwV9Lst25AkvMDnvxODugjdl6KZgwKM1WYQ==}
     engines: {node: '>= 10.x'}
-    dev: false
 
   /sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
@@ -9959,19 +10065,6 @@ packages:
       postcss-selector-parser: 6.0.11
     dev: false
 
-  /sucrase@3.29.0:
-    resolution: {integrity: sha512-bZPAuGA5SdFHuzqIhTAqt9fvNEo9rESqXIG3oiKdF8K4UmkQxC4KlNL3lVyAErXp+mPvUqZ5l13qx6TrDIGf3A==}
-    engines: {node: '>=8'}
-    hasBin: true
-    dependencies:
-      commander: 4.1.1
-      glob: 7.1.6
-      lines-and-columns: 1.2.4
-      mz: 2.7.0
-      pirates: 4.0.6
-      ts-interface-checker: 0.1.13
-    dev: true
-
   /sucrase@3.34.0:
     resolution: {integrity: sha512-70/LQEZ07TEcxiU2dz51FKaE6hCTWC6vr7FOk3Gr0U60C3shtAN+H+BFr9XlYe5xqf3RA8nrc+VIwzCfnxuXJw==}
     engines: {node: '>=8'}
@@ -10037,6 +10130,10 @@ packages:
     resolution: {integrity: sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==}
     engines: {node: '>=6'}
 
+  /tarn@3.0.2:
+    resolution: {integrity: sha512-51LAVKUSZSVfI05vjPESNc5vwqqZpbXCsU+/+wxlOrUjk2SnFTt97v9ZgQrD4YmxYW1Px6w2KjaDitCfkvgxMQ==}
+    engines: {node: '>=8.0.0'}
+
   /terser-webpack-plugin@5.3.7(webpack@5.76.1):
     resolution: {integrity: sha512-AfKwIktyP7Cu50xNjXF/6Qb5lBNzYaWpU6YfoX3uZicTx0zTy0stDDCsvjDapKsSDvOeWo5MEq4TmdBy2cNoHw==}
     engines: {node: '>= 10.13.0'}
@@ -10100,6 +10197,10 @@ packages:
   /thunky@1.1.0:
     resolution: {integrity: sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==}
     dev: false
+
+  /tildify@2.0.0:
+    resolution: {integrity: sha512-Cc+OraorugtXNfs50hU9KS369rFXCfgGLpfCfvlc+Ud5u6VWmUQsOAa9HbTvheQdYnrdJqqv1e5oIqXppMYnSw==}
+    engines: {node: '>=8'}
 
   /tiny-invariant@1.3.1:
     resolution: {integrity: sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw==}
@@ -10212,9 +10313,9 @@ packages:
       joycon: 3.1.1
       postcss-load-config: 3.1.4
       resolve-from: 5.0.0
-      rollup: 3.10.1
+      rollup: 3.26.3
       source-map: 0.8.0-beta.0
-      sucrase: 3.29.0
+      sucrase: 3.34.0
       tree-kill: 1.2.2
       typescript: 4.9.4
     transitivePeerDependencies:
@@ -10248,9 +10349,9 @@ packages:
       joycon: 3.1.1
       postcss-load-config: 3.1.4
       resolve-from: 5.0.0
-      rollup: 3.10.1
+      rollup: 3.26.3
       source-map: 0.8.0-beta.0
-      sucrase: 3.29.0
+      sucrase: 3.34.0
       tree-kill: 1.2.2
       typescript: 4.9.5
     transitivePeerDependencies:
@@ -10698,7 +10799,7 @@ packages:
       esbuild: 0.16.17
       postcss: 8.4.21
       resolve: 1.22.1
-      rollup: 3.10.1
+      rollup: 3.26.3
     optionalDependencies:
       fsevents: 2.3.2
 


### PR DESCRIPTION
# Use case

We sometimes want to create SQL read models and so far I've been asking people to write out SQL manually. This is a fine way to get started but can lead to a lot of code.

Here we introduce a projection library that allows you to specify updates as `Insert`, `Update`, `Delete`, and `Upsert`. The library takes care of intelligently collapsing change sets utilising the guarantee that each call to the handler is for a single stream and therefore a single entity and therefore is safely collapsible. This library is not meant for use cases where that does not hold.

This optimises the number of roundtrips required to the database server to 1 for each changeset.

## Example use

```ts
function changes(streamName: string, events: ITimelineEvent<string>[]): Change[] {
   const id = AppointmentId.parse(StreamName.parseId(streamName))
   const decodedEvents = keepMap(events, Appointment.codec.tryDecode)
   const result: AppointmentChange[] = []
   for (const event of decodedEvents) {
     switch (event.type) {
       case "AppointmentScheduled":
         result.push(
           Insert({ id, title: event.data.title, start: event.data.start, duration_ms: event.data.duration_ms, is_cancelled: false }))
       case "AppointmentRescheduled":
         result.push(Update({ id, start: event.data.start }))
       case "AppointmentCancelled":
         result.push(Update({ id, is_cancelled: true }))
     }
   }
   return result
 }
```

# Todo

- [ ] Support idempotency via a version column