### PR TITLE
fix intro.md

### DIFF
--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -98,7 +98,7 @@ export function create(context: MessageDbContext, cache: ICache) {
     caching,
     access
   )
-  const resolve = (id: AccountId) => Decider.forStream(category, Stream.id(id), context)
+  const resolve = (id: AccountId) => Decider.forStream(category, Stream.id(id), null)
   return new Service(resolve)
 }
 ```

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -88,15 +88,15 @@ import { ICache, CachingStrategy, Decider } from "@equinox-js/core"
 
 export function create(context: MessageDbContext, cache: ICache) {
   const caching = CachingStrategy.Cache(cache)
-  const access = AccessStrategy.Unoptimized
+  const access = AccessStrategy.Unoptimized()
   const category = MessageDbCategory.create(
     context,
     Stream.Category,
     Events.codec,
     Fold.fold,
     Fold.initial,
-    cache,
-    access()
+    caching,
+    access
   )
   const resolve = (id: AccountId) => Decider.forStream(category, Stream.id(id), context)
   return new Service(resolve)

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -95,10 +95,10 @@ export function create(context: MessageDbContext, cache: ICache) {
     Events.codec,
     Fold.fold,
     Fold.initial,
-    access,
     cache,
+    access()
   )
-  const resolve = (id: AccountId) => Decider.forStream(category, Stream.id(id))
+  const resolve = (id: AccountId) => Decider.forStream(category, Stream.id(id), context)
   return new Service(resolve)
 }
 ```


### PR DESCRIPTION
Addresses an issue in the intro.md file to be consistent with the current implementation. 
- AccessStrategy is a function
- order of parameters do not match method signature
- forStream requires a context