### PR TITLE
fix: use consumerGroupMember in groupName

### DIFF
--- a/packages/message-db/message-db-consumer/src/lib/MessageDbSource.mts
+++ b/packages/message-db/message-db-consumer/src/lib/MessageDbSource.mts
@@ -95,8 +95,12 @@ export class MessageDbSource {
   static create(options: Options & { pool: Pool }) {
     const client = new MessageDbCategoryReader(options.pool)
     const sink = options.sink
+    let groupName = options.groupName
+    if (options.consumerGroupMember != null) {
+      groupName = `${groupName}-${options.consumerGroupMember}`
+    }
     sink.addTracingAttrs({
-      "eqx.consumer_group": options.groupName,
+      "eqx.consumer_group": groupName,
       "eqx.tail_sleep_interval_ms": options.tailSleepIntervalMs,
       "eqx.source": "MessageDb",
       [Tags.batch_size]: options.batchSize ?? defaultBatchSize,
@@ -108,7 +112,7 @@ export class MessageDbSource {
       options.statsIntervalMs,
       options.tailSleepIntervalMs,
       options.checkpointIntervalMs ?? 5000,
-      options.groupName,
+      groupName,
       options.consumerGroupMember,
       options.consumerGroupSize,
       options.checkpoints,


### PR DESCRIPTION
resolves #93

appends `-{groupMember}` to the groupName before passing it on.

This will require a major version update since this bug has existed for well over 2 years